### PR TITLE
Added AnimOverride to global lua types

### DIFF
--- a/Lua/GlobalLuaTypes.cs
+++ b/Lua/GlobalLuaTypes.cs
@@ -25,5 +25,6 @@ class MoreLuaPower_GlobalLuaTypes
         UserData.RegisterType<Location>(InteropAccessMode.Default, null);
         UserData.RegisterType<ArcType>(InteropAccessMode.Default, null);
         UserData.RegisterType<GunPointSetting>(InteropAccessMode.Default, null);
+        UserData.RegisterType<AnimationOverrider>(InteropAccessMode.Default, null);
     }
 }


### PR DESCRIPTION
This lets us override our animations with modded controllers.
EX: item.being.animOverrider.controllerName = "MyOtherCharacterName"