### PR TITLE
CustomSettings.cs | Folders, Text Boxes and UI Updates

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -446,9 +446,9 @@ MoreLuaPower:
 
 		// eg. AddSettingFolder ("Hazel's Stuff")
 		//     AddSettingToggle("Hazel's Stuff/Wrench", true)
-		// Pressing the 'Hazel's Stuff' button will show:
-		// Wrench: true
-		// Return?
+
+		// Use the full folder-setting name when getting setting values from settings in folders
+		// eg. GetSettingToggle ("Hazel's Stuff/Wrench")
 
 	bool GetSettingToggle(string name)
 		// Returns the current value of the Toggle setting named {name}.

--- a/API.txt
+++ b/API.txt
@@ -462,7 +462,7 @@ MoreLuaPower:
 		// This ranges from 0-1, assuming players do not make modifications to how sliders or settings work to allow values past maximums.
 
 	string GetSettingTextBox (string name)
-		// Returns the current entered text in the text box named {name}/
+		// Returns the current entered text in the text box named {name}
 
 	List<string> GetSettingFolder(string name)
 		// Returns the list of settings currently in the folder named {name}.

--- a/API.txt
+++ b/API.txt
@@ -433,6 +433,19 @@ MoreLuaPower:
 		// (starting at {defaultval}).
 		// Settings share names across mods, so make sure your name is not too generic!
 
+	void AddSettingFolder(string {name})
+		// Adds a folder setting named {name} which can be used to sort and organize settings.
+		// The folder setting can be pressed to open a one-page menu of added settings.
+		// Name ({name}) another setting 'FolderName/SettingName' to add it to the folder.
+		// The 'FolderName/' will be removed when viewing the setting in the folder.
+		// Folders can hold an infite amount of settings but will only show 18 as it is a single page.
+
+		// eg. AddSettingFolder ("Hazel's Stuff")
+		//     AddSettingToggle("Hazel's Stuff/Wrench", true)
+		// Pressing the 'Hazel's Stuff' button will show:
+		// Wrench: true
+		// Return?
+
 	bool GetSettingToggle(string name)
 		// Returns the current value of the Toggle setting named {name}.
 
@@ -443,6 +456,9 @@ MoreLuaPower:
 	float GetSettingSlider(string name)
 		// Returns the current value of the Slider setting named {name}.
 		// This ranges from 0-1, assuming players do not make modifications to how sliders or settings work to allow values past maximums.
+
+	List<string> GetSettingFolder(string name)
+		// Returns the list of settings currently in the folder.
 
 Lua-based:
 

--- a/API.txt
+++ b/API.txt
@@ -433,6 +433,10 @@ MoreLuaPower:
 		// (starting at {defaultval}).
 		// Settings share names across mods, so make sure your name is not too generic!
 
+	void AddSettingTextBox( string {name}, string {placeholder} (optional) )
+		// Adds an editable text field setting named {name}.
+		// {placeholder} is shown when no text has been entered into the input field. 
+
 	void AddSettingFolder(string {name})
 		// Adds a folder setting named {name} which can be used to sort and organize settings.
 		// The folder setting can be pressed to open a one-page menu of added settings.
@@ -457,8 +461,11 @@ MoreLuaPower:
 		// Returns the current value of the Slider setting named {name}.
 		// This ranges from 0-1, assuming players do not make modifications to how sliders or settings work to allow values past maximums.
 
+	string GetSettingTextBox (string name)
+		// Returns the current entered text in the text box named {name}/
+
 	List<string> GetSettingFolder(string name)
-		// Returns the list of settings currently in the folder.
+		// Returns the list of settings currently in the folder named {name}.
 
 Lua-based:
 

--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -184,7 +184,6 @@ static class MPLCustomSettings
             settings.Add(name, setting);
 
             setting.values = new List<string>();
-            setting.values.Add(name);
             setting.values.Add(placeholder);
         }
         else
@@ -606,7 +605,7 @@ class SettingsPatch
 
                         setting.control = setting.settingobj.transform;
                         setting.control.GetComponent<NavTextfield>().btnCtrl = S.I.optCtrl.btnCtrl;
-                        setting.control.GetComponent<NavTextfield>().name = "MoreLuaPowerSettingsNavTextField" + setting.values[0];
+                        setting.control.GetComponent<NavTextfield>().name = "MoreLuaPowerSettingsNavTextField" + setting.key;
 
                         Object.DestroyImmediate(setting.settingobj.GetComponent<Image>());
                         setting.settingobj.AddComponent<TextMeshProUGUI>();
@@ -622,17 +621,19 @@ class SettingsPatch
                         setting.control.GetComponent<TMP_InputField>().textComponent.fontSize = InputFieldGUIRef.fontSize;
                         setting.control.GetComponent<TMP_InputField>().textComponent.color = new Color(0.8f, 0.8f, 0.8f);
                         setting.control.GetComponent<TMP_InputField>().textComponent.font = InputFieldGUIRef.font;
-                        setting.control.GetComponent<TMP_InputField>().textComponent.alignment = TextAlignmentOptions.Left;
+                        setting.control.GetComponent<TMP_InputField>().textComponent.alignment = TextAlignmentOptions.Left;        
                         setting.control.GetComponent<TMP_InputField>().placeholder.GetComponent<TextMeshProUGUI>().fontStyle = FontStyles.Normal;
                         setting.control.GetComponent<TMP_InputField>().placeholder.GetComponent<TextMeshProUGUI>().fontSize = InputFieldGUIRef.fontSize;
-                        setting.control.GetComponent<TMP_InputField>().placeholder.GetComponent<TextMeshProUGUI>().SetText(setting.values[1]);
+                        setting.control.GetComponent<TMP_InputField>().placeholder.GetComponent<TextMeshProUGUI>().SetText(setting.values[0]);
                         setting.control.GetComponent<TMP_InputField>().placeholder.GetComponent<I2.Loc.Localize>().Term = "";
+
+                        setting.control.GetComponent<TMP_InputField>().characterLimit = 14;
 
                         MPLCustomSettings.TextBoxDistanceUpdate(setting);
 
-                        if (PlayerPrefs.HasKey(setting.values[0]))
+                        if (PlayerPrefs.HasKey(setting.key))
                         {
-                            setting.control.GetComponent<TMP_InputField>().text = PlayerPrefs.GetString(setting.values[0]);
+                            setting.control.GetComponent<TMP_InputField>().text = PlayerPrefs.GetString(setting.key);
                         }
                         else
                         {

--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -286,7 +286,14 @@ static class MPLCustomSettings
 
             foreach (MPLSetting option in settings.Values)
             {
-                if (option.settingobj.activeSelf & S.I.optCtrl.content.activeSelf) { S.I.optCtrl.btnCtrl.SetFocus(option.settingobj); break; }
+                if (option.settingobj.activeSelf & S.I.optCtrl.content.activeSelf) 
+                { 
+                    S.I.optCtrl.btnCtrl.SetFocus(option.settingobj);
+                    if (option.type != SettingType.Return)
+                    {
+                        break;
+                    }
+                }
             }
 
             return;
@@ -380,6 +387,11 @@ static class MPLCustomSettings
                             pair.Value.name = pair.Value.name.Replace(folder + "/", string.Empty);
                             pair.Value.control.GetComponent<TextMeshProUGUI>().text =
                             pair.Value.control.GetComponent<TextMeshProUGUI>().text.Replace(folder + "/", string.Empty);
+
+                            if (pair.Value.type == SettingType.TextField)
+                            {
+                                TextBoxDistanceUpdate(pair.Value);
+                            }
                         }
                         pair.Value.inFolder = true;
 
@@ -404,6 +416,18 @@ static class MPLCustomSettings
             }
         }
     }
+    internal static void TextBoxDistanceUpdate(MPLSetting setting)
+    {
+        setting.control.GetComponent<TextMeshProUGUI>().ForceMeshUpdate();
+
+        string _TextBoxText = setting.control.GetComponent<TextMeshProUGUI>().text;
+        float _TextBoxSize1 = setting.control.GetComponent<TextMeshProUGUI>().GetTextInfo(_TextBoxText).characterInfo[0].topLeft.x;
+        float _TextBoxSize2 = setting.control.GetComponent<TextMeshProUGUI>().GetTextInfo(_TextBoxText).characterInfo[_TextBoxText.Length - 1].bottomRight.x;
+        float _TextBoxDis = setting.control.GetComponent<TextMeshProUGUI>().transform.position.x + (_TextBoxSize2 - _TextBoxSize1 + 2)
+                            - setting.control.GetComponent<NavTextfield>().transform.GetChild(0).position.x;
+
+        setting.control.GetComponent<NavTextfield>().transform.GetChild(0).Translate(_TextBoxDis, 0, 0);
+    }
 }
 
 [HarmonyPatch(typeof(OptionCtrl))]
@@ -414,7 +438,6 @@ class SettingsPatch
     {
         if (MPLCustomSettings.SettingsSetUp == false)
         {
-
             var button = Object.Instantiate(__instance.navButtonGrid.GetChild(1), __instance.navButtonGrid);
             button.GetComponent<UIButton>().tmpText.text = "MODS";
             button.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "MODS";
@@ -596,14 +619,7 @@ class SettingsPatch
                         setting.control.GetComponent<TMP_InputField>().placeholder.GetComponent<TextMeshProUGUI>().SetText(setting.values[1]);
                         setting.control.GetComponent<TMP_InputField>().placeholder.GetComponent<I2.Loc.Localize>().Term = "";
 
-                        setting.control.GetComponent<TextMeshProUGUI>().ForceMeshUpdate();
-
-                        string _TextBoxText = setting.control.GetComponent<TextMeshProUGUI>().text;
-                        float _TextBoxSize1 = setting.control.GetComponent<TextMeshProUGUI>().GetTextInfo(_TextBoxText).characterInfo[0].topLeft.x;
-                        float _TextBoxSize2 = setting.control.GetComponent<TextMeshProUGUI>().GetTextInfo(_TextBoxText).characterInfo[_TextBoxText.Length - 1].bottomRight.x;
-                        float _TextBotSize = _TextBoxSize2 - _TextBoxSize1;
-
-                        setting.control.GetComponent<NavTextfield>().transform.GetChild(0).Translate(_TextBotSize + 2, 0, 0);
+                        MPLCustomSettings.TextBoxDistanceUpdate(setting);
 
                         if (PlayerPrefs.HasKey(setting.values[0]))
                         {

--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -1,23 +1,30 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using System.Collections.Generic;
+using System.Linq;
 using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
-
-enum SettingType { 
+enum SettingType {
     Toggle,
-	Rotation,
-	Slider
+    Rotation,
+    Slider,
+    Folder,
+
+    Return // Used for folder return button
 }
 
 class MPLSetting {
 	public string name;
 	public SettingType type;
 	public List<string> values;
+
 	public int activeValue = 0;
 	public int defaultValue = 0;
 	public float defaultSliderValue = 0;
+
+	public bool inFolder = false;
+
 	public GameObject settingobj;
 	public Transform control;
 }
@@ -29,7 +36,12 @@ static class MPLCustomSettings
 	public static int settingsPage = 0;
 	public static Transform previousPage;
 	public static Transform nextPage;
-	public static bool GetSettingToggle(string name) {
+
+    	internal static bool folderActive = false;
+    	internal static string currentFolder = "FolderSetup|Outside";
+    	internal static string folderReturnKey = "FolderSetup|ReturnKey";
+
+    	public static bool GetSettingToggle(string name) {
 		if (!settings.ContainsKey(name)) {
 			MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
 			return false;
@@ -62,7 +74,29 @@ static class MPLCustomSettings
 		}
 		return PlayerPrefs.GetFloat(name);
 	}
-	public static void AddSettingToggle(string name, bool defaultval) {
+    public static List<string> GetSettingFolder(string name)
+    {
+        if (name == null)
+        {
+            MPLog.Log("Null setting name given!", LogLevel.Major);
+            return null;
+        }
+        if (!settings.ContainsKey(name))
+        {
+            MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
+            return null;
+        }
+        if (settings[name].type != SettingType.Folder)
+        {
+            MPLog.Log("Setting " + name + " is a " + settings[name].type.ToString() + ", when a Folder was asked for.", LogLevel.Major);
+            return null;
+        }
+
+        UpdateFolders();
+        return settings[name].values;
+    }
+
+    public static void AddSettingToggle(string name, bool defaultval) {
 		if (!settings.ContainsKey(name)) {
 			MPLSetting setting = new MPLSetting();
 			setting.name = name;
@@ -96,7 +130,33 @@ static class MPLCustomSettings
 			MPLog.Log("Setting " + name + " was not added as it was already an initialized setting", LogLevel.Minor);
 		}
 	}
-	public static void NextSettingsPage() {
+    public static void AddSettingFolder(string name)
+    {
+        if (name == null)
+        {
+            MPLog.Log("Null setting name given!", LogLevel.Minor);
+            return;
+        }
+        if (settings.ContainsKey(name))
+        {
+            MPLog.Log("Folder '" + name + "' is already an initialized setting", LogLevel.Minor);
+            return;
+        }
+
+        MPLSetting setting = new MPLSetting();
+        setting.name = name;
+        setting.values = new List<string>();
+        setting.type = SettingType.Folder;
+
+        List<KeyValuePair<string, MPLSetting>> sorted = settings.ToList();
+        int folderCount = 0;
+        foreach (MPLSetting value in settings.Values) { if (value.type == SettingType.Folder) { folderCount++; } }
+        sorted.Insert(folderCount, new KeyValuePair<string, MPLSetting>(name, setting));
+        settings.Clear();
+        foreach (KeyValuePair<string, MPLSetting> pair in sorted) { settings.Add(pair.Key, pair.Value); }
+    }
+
+    public static void NextSettingsPage() {
 		if (settings.Count > settingsPage * 18 + 2) {
 			settingsPage++;
 			UpdateSettingsPage();
@@ -109,8 +169,57 @@ static class MPLCustomSettings
 		}
 	}
 	public static void UpdateSettingsPage() {
-		int controlNum = 0;
-		foreach (MPLSetting setting in settings.Values) {
+        if (settings.ContainsKey(folderReturnKey)) { settings[folderReturnKey].settingobj.SetActive(false); }
+
+        foreach (KeyValuePair<string, MPLSetting> pair in settings)
+        {
+            pair.Value.control.GetComponent<TextMeshProUGUI>().color= U.I.GetColor(UIColor.White);
+        }
+        nextPage.GetChild(0).GetComponent<TextMeshProUGUI>().color = U.I.GetColor(UIColor.White);
+        previousPage.GetChild(0).GetComponent<TextMeshProUGUI>().color = U.I.GetColor(UIColor.White);
+
+        int controlNum = 0;
+
+        if (folderActive)
+		{
+			foreach (KeyValuePair<string, MPLSetting> pair in settings)
+			{
+				MPLSetting option = pair.Value;
+                option.settingobj.SetActive(false);
+                if (pair.Key.StartsWith(currentFolder + "/") & pair.Value.inFolder)
+				{
+                    if (controlNum < 18)
+					{
+						controlNum++;
+                        option.settingobj.SetActive(true);
+                    }
+                }
+            }
+
+			settings[folderReturnKey].settingobj.SetActive(true);
+
+            previousPage.gameObject.SetActive(false);
+            nextPage.gameObject.SetActive(false);
+
+            foreach (MPLSetting option in settings.Values)
+			{
+                if (option.settingobj.activeSelf & S.I.optCtrl.content.activeSelf) { S.I.optCtrl.btnCtrl.SetFocus(option.settingobj); break; }
+			}
+
+            return;
+		}
+
+        List<MPLSetting> settingList = new List<MPLSetting>();
+        foreach (KeyValuePair<string, MPLSetting> pair in settings)
+        {
+            if (!pair.Value.inFolder & pair.Key != folderReturnKey)
+            {
+                settingList.Add(pair.Value);
+            }
+            else { pair.Value.settingobj.SetActive(false); }
+        }
+
+        foreach (MPLSetting setting in settingList) {
 			controlNum++;
 			if (controlNum < settingsPage * 18 + 2 && settingsPage != 0) {
 				setting.settingobj.SetActive(false);
@@ -120,16 +229,68 @@ static class MPLCustomSettings
 				setting.settingobj.SetActive(false);
 			}
 		}
-		nextPage.gameObject.SetActive(false);
+
+		if (currentFolder != "FolderSetup|Outside")
+		{
+			if (S.I.optCtrl.content)
+			{
+				S.I.optCtrl.btnCtrl.SetFocus(settings[currentFolder].settingobj);
+                currentFolder = "FolderSetup|Outside";
+			}
+        }
+		else
+		{
+			foreach (MPLSetting option in settings.Values)
+			{
+				if (option.settingobj.activeSelf & S.I.optCtrl.content.activeSelf) { S.I.optCtrl.btnCtrl.SetFocus(option.settingobj); break; }
+			}
+		}
+
+        nextPage.gameObject.SetActive(false);
 		if (settingsPage == 0) {
 			previousPage.gameObject.SetActive(false);
 		} else {
 			previousPage.gameObject.SetActive(true);
 		}
-		if (settings.Count > (settingsPage + 1) * 18 + 2) {
+		if (settingList.Count > (settingsPage + 1) * 18 + 2) {
 			nextPage.gameObject.SetActive(true);
 		} else {
 			nextPage.gameObject.SetActive(false);
+		}
+	}
+	internal static void UpdateFolders()
+	{
+		foreach (MPLSetting setting in settings.Values)
+		{
+			if (setting.type == SettingType.Folder) { setting.values.Clear(); }
+		}
+
+		foreach (KeyValuePair<string, MPLSetting> pair in settings)
+		{
+            if (pair.Key.Contains("/")) 
+			{
+                string folder = pair.Key.Substring(0, pair.Key.IndexOf("/"));
+                if (settings.ContainsKey(folder))
+                {
+                    if (pair.Value.name.StartsWith(folder + "/"))
+					{
+                        pair.Value.name = pair.Value.name.Substring(pair.Value.name.IndexOf("/") + 1);
+                    }
+                    pair.Value.inFolder = true;
+
+                    if (!settings[folder].values.Contains(pair.Value.name))
+                    {
+                        settings[folder].values.Add(pair.Value.name);
+                    }
+                }
+            }
+        }
+
+		if (!settings.ContainsKey(folderReturnKey))
+		{
+			MPLSetting returnBtn = new MPLSetting();
+			returnBtn.type = SettingType.Return;
+			settings.Add(folderReturnKey, returnBtn);
 		}
 	}
 }
@@ -140,9 +301,12 @@ class SettingsPatch
 {
 	static void Prefix(OptionCtrl __instance) {
 		if (MPLCustomSettings.SettingsSetUp == false) {
-			var button = Object.Instantiate(__instance.navButtonGrid.GetChild(1), __instance.navButtonGrid);
+            MPLCustomSettings.UpdateFolders();
+
+            var button = Object.Instantiate(__instance.navButtonGrid.GetChild(1), __instance.navButtonGrid);
 			button.GetComponent<UIButton>().tmpText.text = "MODS";
 			button.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "MODS";
+			if (button.parent.childCount >= 4) { button.SetSiblingIndex(3); }
 
 			var modSettingsMenu = Object.Instantiate(__instance.settingsPane.gameObject);
 			modSettingsMenu.transform.position = __instance.settingsPane.transform.position;
@@ -170,7 +334,9 @@ class SettingsPatch
 			{
 				EventTrigger.Entry entry = new EventTrigger.Entry();
 				entry.eventID = EventTriggerType.PointerClick;
-				entry.callback.AddListener((data) => { S.I.optCtrl.OpenPanel(modSettingsMenu.GetComponent<NavPanel>()); });
+				entry.callback.AddListener((data) => {
+					S.I.optCtrl.OpenPanel(modSettingsMenu.GetComponent<NavPanel>());
+				});
 				EventTrigger trigger = button.gameObject.AddComponent<EventTrigger>();
 				trigger.triggers.Add(entry);
 				trigger.enabled = false;
@@ -193,7 +359,8 @@ class SettingsPatch
 			GameObject PrevButton = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
 			PrevButton.SetActive(true);
 			PrevButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().text = "Previous Page";
-			PrevButton.transform.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "Previous Page";
+            PrevButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().alignment = TextAlignmentOptions.Left;
+            PrevButton.transform.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "Previous Page";
 			Object.DestroyImmediate(PrevButton.GetComponent<Button>());
 			{
 				EventTrigger.Entry entry = new EventTrigger.Entry();
@@ -205,7 +372,7 @@ class SettingsPatch
 			}
 			MPLCustomSettings.previousPage = PrevButton.transform;
 
-			foreach (MPLSetting setting in MPLCustomSettings.settings.Values) {
+            foreach (MPLSetting setting in MPLCustomSettings.settings.Values) {
 				switch (setting.type) {
 					case SettingType.Toggle:
 						if (PlayerPrefs.HasKey(setting.name)) {
@@ -271,14 +438,78 @@ class SettingsPatch
 						}
 						PowerMonoBehavior.sliders.Add(setting.settingobj.transform);
 						break;
+					case SettingType.Folder:
+                        setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
+                        setting.settingobj.SetActive(true);
+                        setting.control = setting.settingobj.transform.GetChild(0);
+                        setting.control.GetComponent<TextMeshProUGUI>().text = setting.name;
+						if (setting.values.Count > 0) 
+						{ 
+							setting.control.GetComponent<TextMeshProUGUI>().text += " [ +" + setting.values.Count.ToString() + " ]"; 
+						}
+						else
+						{
+                            setting.control.GetComponent<TextMeshProUGUI>().text += " []";
+                        }
+
+                        setting.control.GetComponent<TextMeshProUGUI>().fontStyle = FontStyles.Bold;
+                        setting.control.GetComponent<TextMeshProUGUI>().alignment = TextAlignmentOptions.TopLeft;
+
+                        setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
+
+                        Object.DestroyImmediate(setting.settingobj.GetComponent<Button>());
+                        {
+                            EventTrigger.Entry entry = new EventTrigger.Entry();
+                            entry.eventID = EventTriggerType.PointerClick;
+                            entry.callback.AddListener((data) => {
+								MPLCustomSettings.folderActive = true;
+								MPLCustomSettings.currentFolder = setting.name;
+								MPLCustomSettings.UpdateSettingsPage();
+                            });
+
+                            EventTrigger trigger = setting.settingobj.AddComponent<EventTrigger>();
+                            trigger.triggers.Add(entry);
+                            trigger.enabled = false;
+                        }
+
+                        break;
+					case SettingType.Return:
+                        setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
+                        setting.settingobj.SetActive(true);
+                        setting.control = setting.settingobj.transform.GetChild(0);
+                        setting.control.GetComponent<TextMeshProUGUI>().text = "Return?";
+                        setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
+
+                        setting.control.GetComponent<TextMeshProUGUI>().fontStyle = FontStyles.Italic;
+
+                        Object.DestroyImmediate(setting.settingobj.GetComponent<Button>());
+						{
+                            EventTrigger.Entry entry = new EventTrigger.Entry();
+                            entry.eventID = EventTriggerType.PointerClick;
+                            entry.callback.AddListener((data) => {
+                                MPLCustomSettings.folderActive = false;
+                                MPLCustomSettings.UpdateSettingsPage();
+                            });
+
+                            EventTrigger trigger = setting.settingobj.AddComponent<EventTrigger>();
+                            trigger.triggers.Add(entry);
+                            trigger.enabled = false;
+                        }
+                        break;
+
 				}
-			}
+				if (setting.type != SettingType.Folder)
+				{
+					setting.control.GetComponent<TextMeshProUGUI>().alignment = TextAlignmentOptions.Left;
+				}
+            }
 
 			GameObject NextButton = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
 			NextButton.SetActive(true);
 			NextButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().text = "Next Page";
 			NextButton.transform.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "Next Page";
-			Object.DestroyImmediate(NextButton.GetComponent<Button>());
+			NextButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().alignment = TextAlignmentOptions.Left;
+            Object.DestroyImmediate(NextButton.GetComponent<Button>());
 			{
 				EventTrigger.Entry entry = new EventTrigger.Entry();
 				entry.eventID = EventTriggerType.PointerClick;
@@ -289,7 +520,7 @@ class SettingsPatch
 			}
 			MPLCustomSettings.nextPage = NextButton.transform;
 
-			Object.DestroyImmediate(navPanelExit.GetComponent<Button>());
+            Object.DestroyImmediate(navPanelExit.GetComponent<Button>());
 			navPanelExit.gameObject.AddComponent<Button>();
 			navPanelExit.GetComponent<Button>().onClick.AddListener(() => { S.I.optCtrl.ClosePanel(modSettingsMenu.GetComponent<NavPanel>()); });
 			Traverse.Create(navPanelExit.GetComponent<UIButton>()).Field("button").SetValue(navPanelExit.GetComponent<Button>());

--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -578,7 +578,7 @@ class SettingsPatch
                         }
                         else
                         {
-                            setting.control.GetComponent<TMP_InputField>().text = "";
+                            setting.control.GetComponent<TMP_InputField>().text = string.Empty;
                         }
 
                         break;

--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -387,17 +387,22 @@ static class MPLCustomSettings
                             pair.Value.name = pair.Value.name.Replace(folder + "/", string.Empty);
                             pair.Value.control.GetComponent<TextMeshProUGUI>().text =
                             pair.Value.control.GetComponent<TextMeshProUGUI>().text.Replace(folder + "/", string.Empty);
-
-                            if (pair.Value.type == SettingType.TextField)
-                            {
-                                TextBoxDistanceUpdate(pair.Value);
-                            }
                         }
                         pair.Value.inFolder = true;
 
                         if (!settings[folder].values.Contains(pair.Key.Replace(folder + "/", string.Empty)))
                         {
                             settings[folder].values.Add(pair.Key.Replace(folder + "/", string.Empty));
+                        }
+
+                        if (pair.Value.type == SettingType.TextField)
+                        {
+                            TextBoxDistanceUpdate(pair.Value);
+                        }
+
+                        if (pair.Value.type == SettingType.Slider)
+                        {
+                            pair.Value.control.GetComponent<TextMeshProUGUI>().name = pair.Value.name;
                         }
                     }
                 }
@@ -513,9 +518,9 @@ class SettingsPatch
                 switch (setting.type)
                 {
                     case SettingType.Toggle:
-                        if (PlayerPrefs.HasKey(setting.name))
+                        if (PlayerPrefs.HasKey(setting.key))
                         {
-                            setting.activeValue = PlayerPrefs.GetInt(setting.name);
+                            setting.activeValue = PlayerPrefs.GetInt(setting.key);
                         }
                         else
                         {
@@ -541,9 +546,9 @@ class SettingsPatch
                         }
                         break;
                     case SettingType.Rotation:
-                        if (PlayerPrefs.HasKey(setting.name))
+                        if (PlayerPrefs.HasKey(setting.key))
                         {
-                            setting.activeValue = PlayerPrefs.GetInt(setting.name);
+                            setting.activeValue = PlayerPrefs.GetInt(setting.key);
                         }
                         else
                         {
@@ -571,18 +576,22 @@ class SettingsPatch
                     case SettingType.Slider:
                         setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(5).gameObject, navPanelButtons.transform);
                         setting.settingobj.SetActive(true);
-                        setting.settingobj.transform.name = setting.name;
+                        setting.settingobj.transform.name = setting.key;
                         setting.control = setting.settingobj.transform.GetChild(3);
                         setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
+                        setting.control.GetComponent<TextMeshProUGUI>().name = setting.name;
 
                         if (PlayerPrefs.HasKey(setting.key))
                         {
-                            setting.settingobj.GetComponent<Slider>().value = PlayerPrefs.GetFloat(setting.name);
+                            setting.settingobj.GetComponent<Slider>().value = PlayerPrefs.GetFloat(setting.key);
                         }
                         else
                         {
                             setting.settingobj.GetComponent<Slider>().value = setting.defaultSliderValue;
                         }
+
+                        setting.control.GetComponent<TextMeshProUGUI>().transform.Translate(8, 0, 0);
+
                         PowerMonoBehavior.sliders.Add(setting.settingobj.transform);
                         break;
                     case SettingType.TextField:

--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -5,7 +5,8 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
-enum SettingType {
+enum SettingType
+{
     Toggle,
     Rotation,
     Slider,
@@ -14,66 +15,76 @@ enum SettingType {
     Return // Used for folder return button
 }
 
-class MPLSetting {
-	public string name;
-	public SettingType type;
-	public List<string> values;
+class MPLSetting
+{
+    public string name;
+    public SettingType type;
+    public List<string> values;
 
-	public int activeValue = 0;
-	public int defaultValue = 0;
-	public float defaultSliderValue = 0;
+    public int activeValue = 0;
+    public int defaultValue = 0;
+    public float defaultSliderValue = 0;
 
-	public bool inFolder = false;
+    public bool inFolder = false;
 
-	public GameObject settingobj;
-	public Transform control;
+    public GameObject settingobj;
+    public Transform control;
 }
 
 static class MPLCustomSettings
 {
-	public static bool SettingsSetUp = false;
-	public static Dictionary<string, MPLSetting> settings = new Dictionary<string, MPLSetting>();
-	public static int settingsPage = 0;
-	public static Transform previousPage;
-	public static Transform nextPage;
+    public static bool SettingsSetUp = false;
+    public static Dictionary<string, MPLSetting> settings = new Dictionary<string, MPLSetting>();
+    public static int settingsPage = 0;
+    public static Transform previousPage;
+    public static Transform nextPage;
 
-    	internal static bool folderActive = false;
-    	internal static string currentFolder = "FolderSetup|Outside";
-    	internal static string folderReturnKey = "FolderSetup|ReturnKey";
+    internal static bool folderActive = false;
+    internal static string currentFolder = "FolderSetup|Outside";
+    internal static string folderReturnKey = "FolderSetup|ReturnKey";
 
-    	public static bool GetSettingToggle(string name) {
-		if (!settings.ContainsKey(name)) {
-			MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
-			return false;
-		}
-		if (settings[name].type != SettingType.Toggle) {
-			MPLog.Log("Setting " + name + " is a " + settings[name].type.ToString() + ", when a Toggle was asked for.", LogLevel.Major);
-			return false;
-		}
-		return PlayerPrefs.GetInt(name) > 0 ? true : false;
-	}
-	public static string GetSettingRotation(string name) {
-		if (!settings.ContainsKey(name)) {
-			MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
-			return "";
-		}
-		if (settings[name].type != SettingType.Rotation) {
-			MPLog.Log("Setting " + name + " is a " + settings[name].type.ToString() + ", when a Rotation was asked for.", LogLevel.Major);
-			return "";
-		}
-		return settings[name].values[PlayerPrefs.GetInt(name)];
-	}
-	public static float GetSettingSlider(string name) {
-		if (!settings.ContainsKey(name)) {
-			MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
-			return 0;
-		}
-		if (settings[name].type != SettingType.Slider) {
-			MPLog.Log("Setting " + name + " is a " + settings[name].type.ToString() + ", when a Slider was asked for.", LogLevel.Major);
-			return 0;
-		}
-		return PlayerPrefs.GetFloat(name);
-	}
+    public static bool GetSettingToggle(string name)
+    {
+        if (!settings.ContainsKey(name))
+        {
+            MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
+            return false;
+        }
+        if (settings[name].type != SettingType.Toggle)
+        {
+            MPLog.Log("Setting " + name + " is a " + settings[name].type.ToString() + ", when a Toggle was asked for.", LogLevel.Major);
+            return false;
+        }
+        return PlayerPrefs.GetInt(name) > 0 ? true : false;
+    }
+    public static string GetSettingRotation(string name)
+    {
+        if (!settings.ContainsKey(name))
+        {
+            MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
+            return "";
+        }
+        if (settings[name].type != SettingType.Rotation)
+        {
+            MPLog.Log("Setting " + name + " is a " + settings[name].type.ToString() + ", when a Rotation was asked for.", LogLevel.Major);
+            return "";
+        }
+        return settings[name].values[PlayerPrefs.GetInt(name)];
+    }
+    public static float GetSettingSlider(string name)
+    {
+        if (!settings.ContainsKey(name))
+        {
+            MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
+            return 0;
+        }
+        if (settings[name].type != SettingType.Slider)
+        {
+            MPLog.Log("Setting " + name + " is a " + settings[name].type.ToString() + ", when a Slider was asked for.", LogLevel.Major);
+            return 0;
+        }
+        return PlayerPrefs.GetFloat(name);
+    }
     public static List<string> GetSettingFolder(string name)
     {
         if (name == null)
@@ -96,40 +107,52 @@ static class MPLCustomSettings
         return settings[name].values;
     }
 
-    public static void AddSettingToggle(string name, bool defaultval) {
-		if (!settings.ContainsKey(name)) {
-			MPLSetting setting = new MPLSetting();
-			setting.name = name;
-			setting.type = SettingType.Toggle;
-			setting.defaultValue = defaultval ? 1 : 0;
-			settings.Add(name, setting);
-		} else {
-			MPLog.Log("Setting " + name + " was not added as it was already an initialized setting", LogLevel.Minor);
-		}
-	}
-	public static void AddSettingRotation(string name, List<string> values, int defaultval) {
-		if (!settings.ContainsKey(name)) {
-			MPLSetting setting = new MPLSetting();
-			setting.name = name;
-			setting.values = values;
-			setting.type = SettingType.Rotation;
-			setting.defaultValue = defaultval % setting.values.Count; //doing the modulo for extra safety
-			settings.Add(name, setting);
-		} else {
-			MPLog.Log("Setting " + name + " was not added as it was already an initialized setting", LogLevel.Minor);
-		}
-	}
-	public static void AddSettingSlider(string name, float defaultval) {
-		if (!settings.ContainsKey(name)) {
-			MPLSetting setting = new MPLSetting();
-			setting.name = name;
-			setting.type = SettingType.Slider;
-			setting.defaultSliderValue = defaultval;
-			settings.Add(name, setting);
-		} else {
-			MPLog.Log("Setting " + name + " was not added as it was already an initialized setting", LogLevel.Minor);
-		}
-	}
+    public static void AddSettingToggle(string name, bool defaultval)
+    {
+        if (!settings.ContainsKey(name))
+        {
+            MPLSetting setting = new MPLSetting();
+            setting.name = name;
+            setting.type = SettingType.Toggle;
+            setting.defaultValue = defaultval ? 1 : 0;
+            settings.Add(name, setting);
+        }
+        else
+        {
+            MPLog.Log("Setting " + name + " was not added as it was already an initialized setting", LogLevel.Minor);
+        }
+    }
+    public static void AddSettingRotation(string name, List<string> values, int defaultval)
+    {
+        if (!settings.ContainsKey(name))
+        {
+            MPLSetting setting = new MPLSetting();
+            setting.name = name;
+            setting.values = values;
+            setting.type = SettingType.Rotation;
+            setting.defaultValue = defaultval % setting.values.Count; //doing the modulo for extra safety
+            settings.Add(name, setting);
+        }
+        else
+        {
+            MPLog.Log("Setting " + name + " was not added as it was already an initialized setting", LogLevel.Minor);
+        }
+    }
+    public static void AddSettingSlider(string name, float defaultval)
+    {
+        if (!settings.ContainsKey(name))
+        {
+            MPLSetting setting = new MPLSetting();
+            setting.name = name;
+            setting.type = SettingType.Slider;
+            setting.defaultSliderValue = defaultval;
+            settings.Add(name, setting);
+        }
+        else
+        {
+            MPLog.Log("Setting " + name + " was not added as it was already an initialized setting", LogLevel.Minor);
+        }
+    }
     public static void AddSettingFolder(string name)
     {
         if (name == null)
@@ -156,24 +179,29 @@ static class MPLCustomSettings
         foreach (KeyValuePair<string, MPLSetting> pair in sorted) { settings.Add(pair.Key, pair.Value); }
     }
 
-    public static void NextSettingsPage() {
-		if (settings.Count > settingsPage * 18 + 2) {
-			settingsPage++;
-			UpdateSettingsPage();
-		}
-	}
-	public static void PreviousSettingsPage() {
-		if (settingsPage > 0) {
-			settingsPage--;
-			UpdateSettingsPage();
-		}
-	}
-	public static void UpdateSettingsPage() {
+    public static void NextSettingsPage()
+    {
+        if (settings.Count > settingsPage * 18 + 2)
+        {
+            settingsPage++;
+            UpdateSettingsPage();
+        }
+    }
+    public static void PreviousSettingsPage()
+    {
+        if (settingsPage > 0)
+        {
+            settingsPage--;
+            UpdateSettingsPage();
+        }
+    }
+    public static void UpdateSettingsPage()
+    {
         if (settings.ContainsKey(folderReturnKey)) { settings[folderReturnKey].settingobj.SetActive(false); }
 
         foreach (KeyValuePair<string, MPLSetting> pair in settings)
         {
-            pair.Value.control.GetComponent<TextMeshProUGUI>().color= U.I.GetColor(UIColor.White);
+            pair.Value.control.GetComponent<TextMeshProUGUI>().color = U.I.GetColor(UIColor.White);
         }
         nextPage.GetChild(0).GetComponent<TextMeshProUGUI>().color = U.I.GetColor(UIColor.White);
         previousPage.GetChild(0).GetComponent<TextMeshProUGUI>().color = U.I.GetColor(UIColor.White);
@@ -181,33 +209,33 @@ static class MPLCustomSettings
         int controlNum = 0;
 
         if (folderActive)
-		{
-			foreach (KeyValuePair<string, MPLSetting> pair in settings)
-			{
-				MPLSetting option = pair.Value;
+        {
+            foreach (KeyValuePair<string, MPLSetting> pair in settings)
+            {
+                MPLSetting option = pair.Value;
                 option.settingobj.SetActive(false);
                 if (pair.Key.StartsWith(currentFolder + "/") & pair.Value.inFolder)
-				{
+                {
                     if (controlNum < 18)
-					{
-						controlNum++;
+                    {
+                        controlNum++;
                         option.settingobj.SetActive(true);
                     }
                 }
             }
 
-			settings[folderReturnKey].settingobj.SetActive(true);
+            settings[folderReturnKey].settingobj.SetActive(true);
 
             previousPage.gameObject.SetActive(false);
             nextPage.gameObject.SetActive(false);
 
             foreach (MPLSetting option in settings.Values)
-			{
+            {
                 if (option.settingobj.activeSelf & S.I.optCtrl.content.activeSelf) { S.I.optCtrl.btnCtrl.SetFocus(option.settingobj); break; }
-			}
+            }
 
             return;
-		}
+        }
 
         List<MPLSetting> settingList = new List<MPLSetting>();
         foreach (KeyValuePair<string, MPLSetting> pair in settings)
@@ -219,61 +247,73 @@ static class MPLCustomSettings
             else { pair.Value.settingobj.SetActive(false); }
         }
 
-        foreach (MPLSetting setting in settingList) {
-			controlNum++;
-			if (controlNum < settingsPage * 18 + 2 && settingsPage != 0) {
-				setting.settingobj.SetActive(false);
-			} else if (controlNum < (settingsPage + 1) * 18 + 2 + ((settings.Count == settingsPage * 18 + 2) ? 1 : 0)) {
-				setting.settingobj.SetActive(true);
-			} else {
-				setting.settingobj.SetActive(false);
-			}
-		}
-
-		if (currentFolder != "FolderSetup|Outside")
-		{
-			if (S.I.optCtrl.content)
-			{
-				S.I.optCtrl.btnCtrl.SetFocus(settings[currentFolder].settingobj);
-                currentFolder = "FolderSetup|Outside";
-			}
+        foreach (MPLSetting setting in settingList)
+        {
+            controlNum++;
+            if (controlNum < settingsPage * 18 + 2 && settingsPage != 0)
+            {
+                setting.settingobj.SetActive(false);
+            }
+            else if (controlNum < (settingsPage + 1) * 18 + 2 + ((settings.Count == settingsPage * 18 + 2) ? 1 : 0))
+            {
+                setting.settingobj.SetActive(true);
+            }
+            else
+            {
+                setting.settingobj.SetActive(false);
+            }
         }
-		else
-		{
-			foreach (MPLSetting option in settings.Values)
-			{
-				if (option.settingobj.activeSelf & S.I.optCtrl.content.activeSelf) { S.I.optCtrl.btnCtrl.SetFocus(option.settingobj); break; }
-			}
-		}
+
+        if (currentFolder != "FolderSetup|Outside")
+        {
+            if (S.I.optCtrl.content)
+            {
+                S.I.optCtrl.btnCtrl.SetFocus(settings[currentFolder].settingobj);
+                currentFolder = "FolderSetup|Outside";
+            }
+        }
+        else
+        {
+            foreach (MPLSetting option in settings.Values)
+            {
+                if (option.settingobj.activeSelf & S.I.optCtrl.content.activeSelf) { S.I.optCtrl.btnCtrl.SetFocus(option.settingobj); break; }
+            }
+        }
 
         nextPage.gameObject.SetActive(false);
-		if (settingsPage == 0) {
-			previousPage.gameObject.SetActive(false);
-		} else {
-			previousPage.gameObject.SetActive(true);
-		}
-		if (settingList.Count > (settingsPage + 1) * 18 + 2) {
-			nextPage.gameObject.SetActive(true);
-		} else {
-			nextPage.gameObject.SetActive(false);
-		}
-	}
-	internal static void UpdateFolders()
-	{
-		foreach (MPLSetting setting in settings.Values)
-		{
-			if (setting.type == SettingType.Folder) { setting.values.Clear(); }
-		}
+        if (settingsPage == 0)
+        {
+            previousPage.gameObject.SetActive(false);
+        }
+        else
+        {
+            previousPage.gameObject.SetActive(true);
+        }
+        if (settingList.Count > (settingsPage + 1) * 18 + 2)
+        {
+            nextPage.gameObject.SetActive(true);
+        }
+        else
+        {
+            nextPage.gameObject.SetActive(false);
+        }
+    }
+    internal static void UpdateFolders()
+    {
+        foreach (MPLSetting setting in settings.Values)
+        {
+            if (setting.type == SettingType.Folder) { setting.values.Clear(); }
+        }
 
-		foreach (KeyValuePair<string, MPLSetting> pair in settings)
-		{
-            if (pair.Key.Contains("/")) 
-			{
+        foreach (KeyValuePair<string, MPLSetting> pair in settings)
+        {
+            if (pair.Key.Contains("/"))
+            {
                 string folder = pair.Key.Substring(0, pair.Key.IndexOf("/"));
                 if (settings.ContainsKey(folder))
                 {
                     if (pair.Value.name.StartsWith(folder + "/"))
-					{
+                    {
                         pair.Value.name = pair.Value.name.Substring(pair.Value.name.IndexOf("/") + 1);
                     }
                     pair.Value.inFolder = true;
@@ -286,169 +326,183 @@ static class MPLCustomSettings
             }
         }
 
-		if (!settings.ContainsKey(folderReturnKey))
-		{
-			MPLSetting returnBtn = new MPLSetting();
-			returnBtn.type = SettingType.Return;
-			settings.Add(folderReturnKey, returnBtn);
-		}
-	}
+        if (!settings.ContainsKey(folderReturnKey))
+        {
+            MPLSetting returnBtn = new MPLSetting();
+            returnBtn.type = SettingType.Return;
+            settings.Add(folderReturnKey, returnBtn);
+        }
+    }
 }
 
 [HarmonyPatch(typeof(OptionCtrl))]
 [HarmonyPatch("Open")]
 class SettingsPatch
 {
-	static void Prefix(OptionCtrl __instance) {
-		if (MPLCustomSettings.SettingsSetUp == false) {
+    static void Prefix(OptionCtrl __instance)
+    {
+        if (MPLCustomSettings.SettingsSetUp == false)
+        {
             MPLCustomSettings.UpdateFolders();
 
             var button = Object.Instantiate(__instance.navButtonGrid.GetChild(1), __instance.navButtonGrid);
-			button.GetComponent<UIButton>().tmpText.text = "MODS";
-			button.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "MODS";
-			if (button.parent.childCount >= 4) { button.SetSiblingIndex(3); }
+            button.GetComponent<UIButton>().tmpText.text = "MODS";
+            button.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "MODS";
+            if (button.parent.childCount >= 4) { button.SetSiblingIndex(3); }
 
-			var modSettingsMenu = Object.Instantiate(__instance.settingsPane.gameObject);
-			modSettingsMenu.transform.position = __instance.settingsPane.transform.position;
-			modSettingsMenu.transform.SetParent(__instance.settingsPane.transform.parent);
-			var settingsPane = modSettingsMenu.GetComponent<SettingsPane>();
-			GameObject _content = settingsPane.content;
-			SlideBody _slideBody = settingsPane.slideBody;
-			Animator _anim = settingsPane.anim;
-			TMP_Text _title = settingsPane.title;
-			UIButton _defaultButton = settingsPane.defaultButton;
-			UIButton _backButton = settingsPane.backButton;
-			UIButton _originButton = settingsPane.originButton;
-			Object.DestroyImmediate(settingsPane);
-			modSettingsMenu.AddComponent<NavPanel>();
-			var newPane = modSettingsMenu.GetComponent<NavPanel>();
-			newPane.content = _content;
-			newPane.slideBody = _slideBody;
-			newPane.anim = _anim;
-			newPane.title = _title;
-			newPane.defaultButton = _defaultButton;
-			newPane.backButton = _backButton;
-			newPane.originButton = _originButton;
+            var modSettingsMenu = Object.Instantiate(__instance.settingsPane.gameObject);
+            modSettingsMenu.transform.position = __instance.settingsPane.transform.position;
+            modSettingsMenu.transform.SetParent(__instance.settingsPane.transform.parent);
+            var settingsPane = modSettingsMenu.GetComponent<SettingsPane>();
+            GameObject _content = settingsPane.content;
+            SlideBody _slideBody = settingsPane.slideBody;
+            Animator _anim = settingsPane.anim;
+            TMP_Text _title = settingsPane.title;
+            UIButton _defaultButton = settingsPane.defaultButton;
+            UIButton _backButton = settingsPane.backButton;
+            UIButton _originButton = settingsPane.originButton;
+            Object.DestroyImmediate(settingsPane);
+            modSettingsMenu.AddComponent<NavPanel>();
+            var newPane = modSettingsMenu.GetComponent<NavPanel>();
+            newPane.content = _content;
+            newPane.slideBody = _slideBody;
+            newPane.anim = _anim;
+            newPane.title = _title;
+            newPane.defaultButton = _defaultButton;
+            newPane.backButton = _backButton;
+            newPane.originButton = _originButton;
 
-			Object.DestroyImmediate(button.GetComponent<Button>());
-			{
-				EventTrigger.Entry entry = new EventTrigger.Entry();
-				entry.eventID = EventTriggerType.PointerClick;
-				entry.callback.AddListener((data) => {
-					S.I.optCtrl.OpenPanel(modSettingsMenu.GetComponent<NavPanel>());
-				});
-				EventTrigger trigger = button.gameObject.AddComponent<EventTrigger>();
-				trigger.triggers.Add(entry);
-				trigger.enabled = false;
-			}
+            Object.DestroyImmediate(button.GetComponent<Button>());
+            {
+                EventTrigger.Entry entry = new EventTrigger.Entry();
+                entry.eventID = EventTriggerType.PointerClick;
+                entry.callback.AddListener((data) => {
+                    S.I.optCtrl.OpenPanel(modSettingsMenu.GetComponent<NavPanel>());
+                });
+                EventTrigger trigger = button.gameObject.AddComponent<EventTrigger>();
+                trigger.triggers.Add(entry);
+                trigger.enabled = false;
+            }
 
-			//button.GetComponent<UIButton>().onAcceptPress.RemoveAllListeners();
+            //button.GetComponent<UIButton>().onAcceptPress.RemoveAllListeners();
 
-			var navPanelBackground = modSettingsMenu.transform.GetChild(0).GetChild(0);
-			var navPanelButtons = modSettingsMenu.transform.GetChild(0).GetChild(1);
-			var navPanelTitle = modSettingsMenu.transform.GetChild(0).GetChild(2);
-			var navPanelExit = modSettingsMenu.transform.GetChild(0).GetChild(3);
+            var navPanelBackground = modSettingsMenu.transform.GetChild(0).GetChild(0);
+            var navPanelButtons = modSettingsMenu.transform.GetChild(0).GetChild(1);
+            var navPanelTitle = modSettingsMenu.transform.GetChild(0).GetChild(2);
+            var navPanelExit = modSettingsMenu.transform.GetChild(0).GetChild(3);
 
-			navPanelTitle.GetComponent<TextMeshProUGUI>().text = "MOD SETTINGS";
-			navPanelTitle.GetComponent<I2.Loc.Localize>().Term = "MOD SETTINGS";
+            navPanelTitle.GetComponent<TextMeshProUGUI>().text = "MOD SETTINGS";
+            navPanelTitle.GetComponent<I2.Loc.Localize>().Term = "MOD SETTINGS";
 
-			for (int i = 0; i < navPanelButtons.transform.childCount; i++) {
-				navPanelButtons.transform.GetChild(i).gameObject.SetActive(false);
-			}
+            for (int i = 0; i < navPanelButtons.transform.childCount; i++)
+            {
+                navPanelButtons.transform.GetChild(i).gameObject.SetActive(false);
+            }
 
-			GameObject PrevButton = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
-			PrevButton.SetActive(true);
-			PrevButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().text = "Previous Page";
+            GameObject PrevButton = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
+            PrevButton.SetActive(true);
+            PrevButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().text = "Previous Page";
             PrevButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().alignment = TextAlignmentOptions.Left;
             PrevButton.transform.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "Previous Page";
-			Object.DestroyImmediate(PrevButton.GetComponent<Button>());
-			{
-				EventTrigger.Entry entry = new EventTrigger.Entry();
-				entry.eventID = EventTriggerType.PointerClick;
-				entry.callback.AddListener((data) => { MPLCustomSettings.PreviousSettingsPage(); });
-				EventTrigger trigger = PrevButton.AddComponent<EventTrigger>();
-				trigger.triggers.Add(entry);
-				trigger.enabled = false;
-			}
-			MPLCustomSettings.previousPage = PrevButton.transform;
+            Object.DestroyImmediate(PrevButton.GetComponent<Button>());
+            {
+                EventTrigger.Entry entry = new EventTrigger.Entry();
+                entry.eventID = EventTriggerType.PointerClick;
+                entry.callback.AddListener((data) => { MPLCustomSettings.PreviousSettingsPage(); });
+                EventTrigger trigger = PrevButton.AddComponent<EventTrigger>();
+                trigger.triggers.Add(entry);
+                trigger.enabled = false;
+            }
+            MPLCustomSettings.previousPage = PrevButton.transform;
 
-            foreach (MPLSetting setting in MPLCustomSettings.settings.Values) {
-				switch (setting.type) {
-					case SettingType.Toggle:
-						if (PlayerPrefs.HasKey(setting.name)) {
-							setting.activeValue = PlayerPrefs.GetInt(setting.name);
-						} else {
-							setting.activeValue = setting.defaultValue;
-						}
-						setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
-						setting.settingobj.SetActive(true);
-						setting.control = setting.settingobj.transform.GetChild(0);
-						setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + (setting.activeValue > 0 ? "True" : "False");
-						setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
-						Object.DestroyImmediate(setting.settingobj.GetComponent<Button>()); 
-						{
-							EventTrigger.Entry entry = new EventTrigger.Entry();
-							entry.eventID = EventTriggerType.PointerClick;
-							entry.callback.AddListener((data) => {
-								setting.activeValue = setting.activeValue > 0 ? 0 : 1;
-								PlayerPrefs.SetInt(setting.name, setting.activeValue);
-								setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + (setting.activeValue > 0 ? "True" : "False");
-							});
-							EventTrigger trigger = setting.settingobj.AddComponent<EventTrigger>();
-							trigger.triggers.Add(entry);
-							trigger.enabled = false;
-						}
-						break;
-					case SettingType.Rotation:
-						if (PlayerPrefs.HasKey(setting.name)) {
-							setting.activeValue = PlayerPrefs.GetInt(setting.name);
-						} else {
-							setting.activeValue = setting.defaultValue;
-						}
-						setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
-						setting.settingobj.SetActive(true);
-						setting.control = setting.settingobj.transform.GetChild(0);
-						setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + setting.values[setting.activeValue];
-						setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
-						Object.DestroyImmediate(setting.settingobj.GetComponent<Button>()); 
-						{
-							EventTrigger.Entry entry = new EventTrigger.Entry();
-							entry.eventID = EventTriggerType.PointerClick;
-							entry.callback.AddListener((data) => {
-								setting.activeValue = (setting.activeValue + 1 < setting.values.Count ? setting.activeValue + 1 : 0);
-								PlayerPrefs.SetInt(setting.name, setting.activeValue);
-								setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + setting.values[setting.activeValue];
-							});
-							EventTrigger trigger = setting.settingobj.AddComponent<EventTrigger>();
-							trigger.triggers.Add(entry);
-							trigger.enabled = false;
-						}
-						break;
-					case SettingType.Slider:
-						setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(5).gameObject, navPanelButtons.transform);
-						setting.settingobj.SetActive(true);
-						setting.settingobj.transform.name = setting.name;
-						setting.control = setting.settingobj.transform.GetChild(3);
-						setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
+            foreach (MPLSetting setting in MPLCustomSettings.settings.Values)
+            {
+                switch (setting.type)
+                {
+                    case SettingType.Toggle:
+                        if (PlayerPrefs.HasKey(setting.name))
+                        {
+                            setting.activeValue = PlayerPrefs.GetInt(setting.name);
+                        }
+                        else
+                        {
+                            setting.activeValue = setting.defaultValue;
+                        }
+                        setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
+                        setting.settingobj.SetActive(true);
+                        setting.control = setting.settingobj.transform.GetChild(0);
+                        setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + (setting.activeValue > 0 ? "True" : "False");
+                        setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
+                        Object.DestroyImmediate(setting.settingobj.GetComponent<Button>());
+                        {
+                            EventTrigger.Entry entry = new EventTrigger.Entry();
+                            entry.eventID = EventTriggerType.PointerClick;
+                            entry.callback.AddListener((data) => {
+                                setting.activeValue = setting.activeValue > 0 ? 0 : 1;
+                                PlayerPrefs.SetInt(setting.name, setting.activeValue);
+                                setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + (setting.activeValue > 0 ? "True" : "False");
+                            });
+                            EventTrigger trigger = setting.settingobj.AddComponent<EventTrigger>();
+                            trigger.triggers.Add(entry);
+                            trigger.enabled = false;
+                        }
+                        break;
+                    case SettingType.Rotation:
+                        if (PlayerPrefs.HasKey(setting.name))
+                        {
+                            setting.activeValue = PlayerPrefs.GetInt(setting.name);
+                        }
+                        else
+                        {
+                            setting.activeValue = setting.defaultValue;
+                        }
+                        setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
+                        setting.settingobj.SetActive(true);
+                        setting.control = setting.settingobj.transform.GetChild(0);
+                        setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + setting.values[setting.activeValue];
+                        setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
+                        Object.DestroyImmediate(setting.settingobj.GetComponent<Button>());
+                        {
+                            EventTrigger.Entry entry = new EventTrigger.Entry();
+                            entry.eventID = EventTriggerType.PointerClick;
+                            entry.callback.AddListener((data) => {
+                                setting.activeValue = (setting.activeValue + 1 < setting.values.Count ? setting.activeValue + 1 : 0);
+                                PlayerPrefs.SetInt(setting.name, setting.activeValue);
+                                setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + setting.values[setting.activeValue];
+                            });
+                            EventTrigger trigger = setting.settingobj.AddComponent<EventTrigger>();
+                            trigger.triggers.Add(entry);
+                            trigger.enabled = false;
+                        }
+                        break;
+                    case SettingType.Slider:
+                        setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(5).gameObject, navPanelButtons.transform);
+                        setting.settingobj.SetActive(true);
+                        setting.settingobj.transform.name = setting.name;
+                        setting.control = setting.settingobj.transform.GetChild(3);
+                        setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
 
-						if (PlayerPrefs.HasKey(setting.name)) {
-							setting.settingobj.GetComponent<Slider>().value = PlayerPrefs.GetFloat(setting.name);
-						} else {
-							setting.settingobj.GetComponent<Slider>().value = setting.defaultSliderValue;
-						}
-						PowerMonoBehavior.sliders.Add(setting.settingobj.transform);
-						break;
-					case SettingType.Folder:
+                        if (PlayerPrefs.HasKey(setting.name))
+                        {
+                            setting.settingobj.GetComponent<Slider>().value = PlayerPrefs.GetFloat(setting.name);
+                        }
+                        else
+                        {
+                            setting.settingobj.GetComponent<Slider>().value = setting.defaultSliderValue;
+                        }
+                        PowerMonoBehavior.sliders.Add(setting.settingobj.transform);
+                        break;
+                    case SettingType.Folder:
                         setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
                         setting.settingobj.SetActive(true);
                         setting.control = setting.settingobj.transform.GetChild(0);
                         setting.control.GetComponent<TextMeshProUGUI>().text = setting.name;
-						if (setting.values.Count > 0) 
-						{ 
-							setting.control.GetComponent<TextMeshProUGUI>().text += " [ +" + setting.values.Count.ToString() + " ]"; 
-						}
-						else
-						{
+                        if (setting.values.Count > 0)
+                        {
+                            setting.control.GetComponent<TextMeshProUGUI>().text += " [ +" + setting.values.Count.ToString() + " ]";
+                        }
+                        else
+                        {
                             setting.control.GetComponent<TextMeshProUGUI>().text += " []";
                         }
 
@@ -462,9 +516,9 @@ class SettingsPatch
                             EventTrigger.Entry entry = new EventTrigger.Entry();
                             entry.eventID = EventTriggerType.PointerClick;
                             entry.callback.AddListener((data) => {
-								MPLCustomSettings.folderActive = true;
-								MPLCustomSettings.currentFolder = setting.name;
-								MPLCustomSettings.UpdateSettingsPage();
+                                MPLCustomSettings.folderActive = true;
+                                MPLCustomSettings.currentFolder = setting.name;
+                                MPLCustomSettings.UpdateSettingsPage();
                             });
 
                             EventTrigger trigger = setting.settingobj.AddComponent<EventTrigger>();
@@ -473,7 +527,7 @@ class SettingsPatch
                         }
 
                         break;
-					case SettingType.Return:
+                    case SettingType.Return:
                         setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
                         setting.settingobj.SetActive(true);
                         setting.control = setting.settingobj.transform.GetChild(0);
@@ -483,7 +537,7 @@ class SettingsPatch
                         setting.control.GetComponent<TextMeshProUGUI>().fontStyle = FontStyles.Italic;
 
                         Object.DestroyImmediate(setting.settingobj.GetComponent<Button>());
-						{
+                        {
                             EventTrigger.Entry entry = new EventTrigger.Entry();
                             entry.eventID = EventTriggerType.PointerClick;
                             entry.callback.AddListener((data) => {
@@ -497,37 +551,37 @@ class SettingsPatch
                         }
                         break;
 
-				}
-				if (setting.type != SettingType.Folder)
-				{
-					setting.control.GetComponent<TextMeshProUGUI>().alignment = TextAlignmentOptions.Left;
-				}
+                }
+                if (setting.type != SettingType.Folder)
+                {
+                    setting.control.GetComponent<TextMeshProUGUI>().alignment = TextAlignmentOptions.Left;
+                }
             }
 
-			GameObject NextButton = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
-			NextButton.SetActive(true);
-			NextButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().text = "Next Page";
-			NextButton.transform.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "Next Page";
-			NextButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().alignment = TextAlignmentOptions.Left;
+            GameObject NextButton = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
+            NextButton.SetActive(true);
+            NextButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().text = "Next Page";
+            NextButton.transform.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "Next Page";
+            NextButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().alignment = TextAlignmentOptions.Left;
             Object.DestroyImmediate(NextButton.GetComponent<Button>());
-			{
-				EventTrigger.Entry entry = new EventTrigger.Entry();
-				entry.eventID = EventTriggerType.PointerClick;
-				entry.callback.AddListener((data) => { MPLCustomSettings.NextSettingsPage(); });
-				EventTrigger trigger = NextButton.AddComponent<EventTrigger>();
-				trigger.triggers.Add(entry);
-				trigger.enabled = false;
-			}
-			MPLCustomSettings.nextPage = NextButton.transform;
+            {
+                EventTrigger.Entry entry = new EventTrigger.Entry();
+                entry.eventID = EventTriggerType.PointerClick;
+                entry.callback.AddListener((data) => { MPLCustomSettings.NextSettingsPage(); });
+                EventTrigger trigger = NextButton.AddComponent<EventTrigger>();
+                trigger.triggers.Add(entry);
+                trigger.enabled = false;
+            }
+            MPLCustomSettings.nextPage = NextButton.transform;
 
             Object.DestroyImmediate(navPanelExit.GetComponent<Button>());
-			navPanelExit.gameObject.AddComponent<Button>();
-			navPanelExit.GetComponent<Button>().onClick.AddListener(() => { S.I.optCtrl.ClosePanel(modSettingsMenu.GetComponent<NavPanel>()); });
-			Traverse.Create(navPanelExit.GetComponent<UIButton>()).Field("button").SetValue(navPanelExit.GetComponent<Button>());
+            navPanelExit.gameObject.AddComponent<Button>();
+            navPanelExit.GetComponent<Button>().onClick.AddListener(() => { S.I.optCtrl.ClosePanel(modSettingsMenu.GetComponent<NavPanel>()); });
+            Traverse.Create(navPanelExit.GetComponent<UIButton>()).Field("button").SetValue(navPanelExit.GetComponent<Button>());
 
-			MPLCustomSettings.UpdateSettingsPage();
+            MPLCustomSettings.UpdateSettingsPage();
 
-			MPLCustomSettings.SettingsSetUp = true;
-		}
-	}
+            MPLCustomSettings.SettingsSetUp = true;
+        }
+    }
 }

--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -318,9 +318,9 @@ static class MPLCustomSettings
                     }
                     pair.Value.inFolder = true;
 
-                    if (!settings[folder].values.Contains(pair.Value.name))
+                    if (!settings[folder].values.Contains(pair.Key.Replace(folder + "/", "")))
                     {
-                        settings[folder].values.Add(pair.Value.name);
+                        settings[folder].values.Add(pair.Key.Replace(folder + "/", ""));
                     }
                 }
             }

--- a/Lua/GlobalLuaFunctions.cs
+++ b/Lua/GlobalLuaFunctions.cs
@@ -89,9 +89,10 @@ class MoreLuaPower_GlobalLuaFunctions
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingToggle"] = (Action<string, bool>)MPLCustomSettings.AddSettingToggle;
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingRotation"] = (Action<string, List<string>, int>)MPLCustomSettings.AddSettingRotation;
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingSlider"] = (Action<string, float>)MPLCustomSettings.AddSettingSlider;
-
 	Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingFolder"] = (Action<string>)MPLCustomSettings.AddSettingFolder;
 	Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["GetSettingFolder"] = (Func<string, List<string>>)MPLCustomSettings.GetSettingFolder;
+	Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingTextBox"] = (Action<string, string>)MPLCustomSettings.AddSettingTextBox;
+	Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["GetSettingTextBox"] = (Func<string, string>)MPLCustomSettings.GetSettingTextBox;
 	}
 }
 

--- a/Lua/GlobalLuaFunctions.cs
+++ b/Lua/GlobalLuaFunctions.cs
@@ -89,6 +89,9 @@ class MoreLuaPower_GlobalLuaFunctions
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingToggle"] = (Action<string, bool>)MPLCustomSettings.AddSettingToggle;
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingRotation"] = (Action<string, List<string>, int>)MPLCustomSettings.AddSettingRotation;
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingSlider"] = (Action<string, float>)MPLCustomSettings.AddSettingSlider;
+
+	Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingFolder"] = (Action<string>)MPLCustomSettings.AddSettingFolder;
+	Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["GetSettingFolder"] = (Func<string, List<string>>)MPLCustomSettings.GetSettingFolder;
 	}
 }
 

--- a/Misc/PowerMonoBehavior.cs
+++ b/Misc/PowerMonoBehavior.cs
@@ -18,21 +18,39 @@ public class PowerMonoBehavior : MonoBehaviour
         for (int i = 0; i < UpdateScripts.Count; i++) {
             S.I.mainCtrl.StartCoroutine(MoreLuaPower_FunctionHelper.EffectRoutine(UpdateBaseScripts[i].CreateCoroutine(UpdateScripts[i])));
         }
-        foreach(Transform slider in sliders) {
-            if (slider == null) { 
-                sliders.Remove(slider);
-                continue;
-            }
-            string temp = slider.GetChild(3).GetComponent<TextMeshProUGUI>().text;
-			slider.GetChild(3).GetComponent<TextMeshProUGUI>().text = string.Format("{0}: {1}", slider.name, slider.GetComponent<Slider>().value) + "%";
-            if (temp != slider.GetChild(3).GetComponent<TextMeshProUGUI>().text) {
-                PlayerPrefs.SetFloat(slider.name, slider.GetComponent<Slider>().value);
-            }
-		}
-        if (Input.GetKeyDown(KeyCode.BackQuote)) {
+	
+        foreach(Transform slider in sliders) 
+	{
+    		if (slider == null) 
+      		{ 
+       			sliders.Remove(slider);
+       			continue;
+    		}
+    		float sliderVal = slider.GetComponent<Slider>().value;
+    		string sliderKey = slider.name;
+    		if (PlayerPrefs.HasKey(sliderKey))
+    		{
+        		if (PlayerPrefs.GetFloat(sliderKey) != sliderVal)
+        		{
+            			PlayerPrefs.SetFloat(sliderKey, sliderVal);
+        		}
+    		}
+    		else
+    		{
+        		PlayerPrefs.SetFloat(sliderKey, sliderVal);
+    		}
+
+    		string sliderNickname = slider.GetChild(3).GetComponent<TextMeshProUGUI>().name;
+
+    		slider.GetChild(3).GetComponent<TextMeshProUGUI>().text = string.Format("{0}: {1}", sliderNickname, sliderVal) + "%";
+	}
+ 
+        if (Input.GetKeyDown(KeyCode.BackQuote)) 
+	{
             EnableDeveloperTools();
         }
     }
+    
     public static List<object> GameUpdateScripts = new List<object>();
     public static List<Script> GameUpdateBaseScripts = new List<Script>();
     public void FixedUpdate() {


### PR DESCRIPTION
Added Folders which contain (hide) settings named "FolderName/SettingName" until pressed. When pressed, updates nav panel to show all settings with the particular naming scheme as well as "Return" button.
Settings shown within the folder will have "FolderName/" removed.

Added Text boxes which can have custom text entered by the player.


Added _Folder_, _Return_ and _TextField_  values to **SettingType**
Added _inFolder_ bool and _key_ string to **MPLSetting** class


Updated API.txt to include **AddSettingFolder**, **GetSettingFolder**, **AddSettingTextBox** and **GetSettingTextBox**


**[Most Important Change]** Moved MODS button index to before Close/Abandon Run/Quit button.

Moved settings text alignment to _Left_ rather than _Center_. Folders use _Top Left_ and _Bold_ to differentiate. 
Cleared coloring from Previous and Next buttons when updating page.