### PR TITLE
Folders, Text Boxes, Buttons and UI Updates

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -437,6 +437,15 @@ MoreLuaPower:
 		// Adds an editable text field setting named {name}.
 		// {placeholder} is shown when no text has been entered into the input field. 
 
+	void AddSettingButton( string {name}, List<string> {functions} )
+		// Adds a pressable button setting named {name}.
+		// When pressed, all the function names in the list of {functions} are activated.
+		// eg. AddSettingButton("Button1", {"Function1"})
+		// eg. AddSettingButton("Button2", {"Function1", "Function2", "Function3"})
+
+	void EditSettingButton ( string {name}, List<string> {functions} )
+		// Changes the function list for {name} to {functions}.
+
 	void AddSettingFolder(string {name})
 		// Adds a folder setting named {name} which can be used to sort and organize settings.
 		// The folder setting can be pressed to open a one-page menu of added settings.

--- a/API.txt
+++ b/API.txt
@@ -442,6 +442,9 @@ MoreLuaPower:
 		// When pressed, all the function names in the list of {functions} are activated.
 		// eg. AddSettingButton("Button1", {"Function1"})
 		// eg. AddSettingButton("Button2", {"Function1", "Function2", "Function3"})
+		// As the game is paused, most things in functions triggered will not actually do anything
+		   unless a 'WaitForSeconds(item, 0)' is placed before it. This causes to game to wait until 
+		   the menu is closed to do anything.
 
 	void EditSettingButton ( string {name}, List<string> {functions} )
 		// Changes the function list for {name} to {functions}.

--- a/API.txt
+++ b/API.txt
@@ -433,6 +433,23 @@ MoreLuaPower:
 		// (starting at {defaultval}).
 		// Settings share names across mods, so make sure your name is not too generic!
 
+	void AddSettingTextBox( string {name}, string {placeholder} (optional) )
+		// Adds an editable text field setting named {name}.
+		// {placeholder} is shown when no text has been entered into the input field. 
+
+	void AddSettingFolder(string {name})
+		// Adds a folder setting named {name} which can be used to sort and organize settings.
+		// The folder setting can be pressed to open a one-page menu of added settings.
+		// Name ({name}) another setting 'FolderName/SettingName' to add it to the folder.
+		// The 'FolderName/' will be removed when viewing the setting in the folder.
+		// Folders can hold an infite amount of settings but will only show 18 as it is a single page.
+
+		// eg. AddSettingFolder ("Hazel's Stuff")
+		//     AddSettingToggle("Hazel's Stuff/Wrench", true)
+
+		// Use the full folder-setting name when getting setting values from settings in folders
+		// eg. GetSettingToggle ("Hazel's Stuff/Wrench")
+
 	bool GetSettingToggle(string name)
 		// Returns the current value of the Toggle setting named {name}.
 
@@ -443,6 +460,12 @@ MoreLuaPower:
 	float GetSettingSlider(string name)
 		// Returns the current value of the Slider setting named {name}.
 		// This ranges from 0-1, assuming players do not make modifications to how sliders or settings work to allow values past maximums.
+
+	string GetSettingTextBox (string name)
+		// Returns the current entered text in the text box named {name}.
+
+	List<string> GetSettingFolder(string name)
+		// Returns the list of settings currently in the folder named {name}.
 
 Lua-based:
 

--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -503,6 +503,7 @@ public static class MPLCustomSettings
 [HarmonyPatch("Open")]
 class SettingsPatch
 {
+    private static NavPanel modSettingsPanelVar = null;
     static void Prefix(OptionCtrl __instance)
     {
         if (MPLCustomSettings.SettingsSetUp == false)
@@ -539,6 +540,7 @@ class SettingsPatch
                 EventTrigger.Entry entry = new EventTrigger.Entry();
                 entry.eventID = EventTriggerType.PointerClick;
                 entry.callback.AddListener((data) => {
+                    modSettingsPanelVar = modSettingsMenu.GetComponent<NavPanel>();
                     S.I.optCtrl.OpenPanel(modSettingsMenu.GetComponent<NavPanel>());
                 });
                 EventTrigger trigger = button.gameObject.AddComponent<EventTrigger>();
@@ -849,33 +851,17 @@ class SettingsPatch
     }
     private static IEnumerator _FirstOpenFocus(NavPanel panel)
     {
-        Transform child = null;
-        Transform title = null;
-        if (panel.transform.childCount > 0)
+        if (panel == null || modSettingsPanelVar == null || modSettingsPanelVar != panel)
         {
-            child = panel.transform.GetChild(0);
-        }
-        if (child.transform.childCount >= 2)
-        {
-            title = child?.GetChild(2);
+            yield break;
         }
 
-        if (title != null)
+        yield return new WaitForSecondsRealtime(0.3f);
+        string settingID = MPLCustomSettings.settings.ToList().Find(x => x.Value.settingobj.activeSelf).Key;
+        if (MPLCustomSettings.settings.ContainsKey(settingID))
         {
-            if (title.GetComponent<TextMeshProUGUI>() != null)
-            {
-                if (title.GetComponent<TextMeshProUGUI>().text == "MOD SETTINGS")
-                {
-                    yield return new WaitForSecondsRealtime(0.3f);
-
-                    string settingID = MPLCustomSettings.settings.ToList().Find(x => x.Value.settingobj.activeSelf).Key;
-                    if (MPLCustomSettings.settings.ContainsKey(settingID))
-                    {
-                        MPLSetting activeSetting = MPLCustomSettings.settings[settingID];
-                        S.I.optCtrl.btnCtrl.SetFocus(activeSetting.settingobj);
-                    }
-                }
-            }
+            MPLSetting activeSetting = MPLCustomSettings.settings[settingID];
+            S.I.optCtrl.btnCtrl.SetFocus(activeSetting.settingobj);
         }
 
         yield break;

--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -349,6 +349,7 @@ public static class MPLCustomSettings
             {
                 S.I.optCtrl.btnCtrl.SetFocus(settings[currentFolder].settingobj);
                 currentFolder = "FolderSetup|Outside";
+                settings[folderReturnKey].values[0] = string.Empty;
             }
         }
         else
@@ -548,6 +549,7 @@ class SettingsPatch
                         setting.control = setting.settingobj.transform.GetChild(0);
                         setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + (setting.activeValue > 0 ? "True" : "False");
                         setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
+
                         Object.DestroyImmediate(setting.settingobj.GetComponent<Button>());
                         {
                             EventTrigger.Entry entry = new EventTrigger.Entry();
@@ -615,26 +617,27 @@ class SettingsPatch
 
                         Transform InputFieldRef = S.I.heCtrl.content.transform.Find("SeedField");
                         TextMeshProUGUI InputFieldGUIRef = navPanelButtons.transform.GetChild(0).GetChild(0).GetComponent<TextMeshProUGUI>();
-
                         NavTextfield TextBoxInputRef = S.I.heCtrl.content.transform.Find("SeedField").GetComponent<NavTextfield>();
 
                         setting.settingobj = Object.Instantiate(InputFieldRef.gameObject, navPanelButtons.transform);
                         setting.settingobj.SetActive(true);
-
                         setting.control = setting.settingobj.transform;
                         setting.control.GetComponent<NavTextfield>().btnCtrl = S.I.optCtrl.btnCtrl;
                         setting.control.GetComponent<NavTextfield>().name = "MoreLuaPowerSettingsNavTextField" + setting.key;
 
                         Object.DestroyImmediate(setting.settingobj.GetComponent<Image>());
+                        //Object.DestroyImmediate(setting.settingobj.GetComponent<TouchScreenKeyboard>());
                         setting.settingobj.AddComponent<TextMeshProUGUI>();
 
                         setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + " :";
                         setting.control.GetComponent<TextMeshProUGUI>().fontSize = InputFieldGUIRef.fontSize;
                         setting.control.GetComponent<TextMeshProUGUI>().font = InputFieldGUIRef.font;
 
-                        setting.control.GetComponent<NavTextfield>().navList = PrevButton.GetComponent<NavButton>().navList;
+                        //setting.control.GetComponent<NavTextfield>().navList = PrevButton.GetComponent<NavButton>().navList;
                         setting.control.GetComponent<NavTextfield>().useParentTransformNav = true;
                         setting.control.GetComponent<NavTextfield>().transform.GetChild(0).GetChild(0).Translate(0, -1f, 0);
+                        setting.control.GetComponent<NavTextfield>().down = null;
+                        setting.control.GetComponent<NavTextfield>().up = null;
 
                         setting.control.GetComponent<TMP_InputField>().textComponent.fontSize = InputFieldGUIRef.fontSize;
                         setting.control.GetComponent<TMP_InputField>().textComponent.color = new Color(0.8f, 0.8f, 0.8f);

--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -34,10 +34,10 @@ class MPLSetting
     public Transform control;
 }
 
-static class MPLCustomSettings
+public static class MPLCustomSettings
 {
     public static bool SettingsSetUp = false;
-    public static Dictionary<string, MPLSetting> settings = new Dictionary<string, MPLSetting>();
+    internal static Dictionary<string, MPLSetting> settings = new Dictionary<string, MPLSetting>();
     public static int settingsPage = 0;
     public static Transform previousPage;
     public static Transform nextPage;

--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -857,11 +857,14 @@ class SettingsPatch
         }
 
         yield return new WaitForSecondsRealtime(0.3f);
-        string settingID = MPLCustomSettings.settings.ToList().Find(x => x.Value.settingobj.activeSelf).Key;
-        if (MPLCustomSettings.settings.ContainsKey(settingID))
+        if (MPLCustomSettings.settings.Count > 0)
         {
-            MPLSetting activeSetting = MPLCustomSettings.settings[settingID];
-            S.I.optCtrl.btnCtrl.SetFocus(activeSetting.settingobj);
+            string settingID = MPLCustomSettings.settings.ToList().Find(x => x.Value.settingobj.activeSelf).Key;
+            if (MPLCustomSettings.settings.ContainsKey(settingID))
+            {
+                MPLSetting activeSetting = MPLCustomSettings.settings[settingID];
+                S.I.optCtrl.btnCtrl.SetFocus(activeSetting.settingobj);
+            }
         }
 
         yield break;

--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -683,6 +683,7 @@ class SettingsPatch
                         setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
 
                         setting.control.GetComponent<TextMeshProUGUI>().fontStyle = FontStyles.Italic;
+                        setting.control.GetComponent<TextMeshProUGUI>().alignment = TextAlignmentOptions.BottomLeft;
 
                         Object.DestroyImmediate(setting.settingobj.GetComponent<Button>());
                         {
@@ -711,7 +712,7 @@ class SettingsPatch
                         }
                         break;
                 }
-                if (setting.type != SettingType.Folder & setting.control.GetComponent<TextMeshProUGUI>() != null)
+                if (setting.type != SettingType.Folder & setting.type != SettingType.Return & setting.control.GetComponent<TextMeshProUGUI>() != null)
                 {
                     setting.control.GetComponent<TextMeshProUGUI>().alignment = TextAlignmentOptions.Left;
                 }

--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -1,302 +1,794 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using System.Collections.Generic;
+using System.Linq;
 using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
-enum SettingType { 
+enum SettingType
+{
     Toggle,
-	Rotation,
-	Slider
+    Rotation,
+    Slider,
+    TextField,
+    Folder,
+
+    Return // Used for folder return button
 }
 
-class MPLSetting {
-	public string name;
-	public SettingType type;
-	public List<string> values;
-	public int activeValue = 0;
-	public int defaultValue = 0;
-	public float defaultSliderValue = 0;
-	public GameObject settingobj;
-	public Transform control;
+class MPLSetting
+{
+    public string name;
+    public string key;
+    public SettingType type;
+    public List<string> values;
+
+    public int activeValue = 0;
+    public int defaultValue = 0;
+    public float defaultSliderValue = 0;
+
+    public bool inFolder = false;
+
+    public GameObject settingobj;
+    public Transform control;
 }
 
 static class MPLCustomSettings
 {
-	public static bool SettingsSetUp = false;
-	public static Dictionary<string, MPLSetting> settings = new Dictionary<string, MPLSetting>();
-	public static int settingsPage = 0;
-	public static Transform previousPage;
-	public static Transform nextPage;
-	public static bool GetSettingToggle(string name) {
-		if (!settings.ContainsKey(name)) {
-			MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
-			return false;
-		}
-		if (settings[name].type != SettingType.Toggle) {
-			MPLog.Log("Setting " + name + " is a " + settings[name].type.ToString() + ", when a Toggle was asked for.", LogLevel.Major);
-			return false;
-		}
-		return PlayerPrefs.GetInt(name) > 0 ? true : false;
-	}
-	public static string GetSettingRotation(string name) {
-		if (!settings.ContainsKey(name)) {
-			MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
-			return "";
-		}
-		if (settings[name].type != SettingType.Rotation) {
-			MPLog.Log("Setting " + name + " is a " + settings[name].type.ToString() + ", when a Rotation was asked for.", LogLevel.Major);
-			return "";
-		}
-		return settings[name].values[PlayerPrefs.GetInt(name)];
-	}
-	public static float GetSettingSlider(string name) {
-		if (!settings.ContainsKey(name)) {
-			MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
-			return 0;
-		}
-		if (settings[name].type != SettingType.Slider) {
-			MPLog.Log("Setting " + name + " is a " + settings[name].type.ToString() + ", when a Slider was asked for.", LogLevel.Major);
-			return 0;
-		}
-		return PlayerPrefs.GetFloat(name);
-	}
-	public static void AddSettingToggle(string name, bool defaultval) {
-		if (!settings.ContainsKey(name)) {
-			MPLSetting setting = new MPLSetting();
-			setting.name = name;
-			setting.type = SettingType.Toggle;
-			setting.defaultValue = defaultval ? 1 : 0;
-			settings.Add(name, setting);
-		} else {
-			MPLog.Log("Setting " + name + " was not added as it was already an initialized setting", LogLevel.Minor);
-		}
-	}
-	public static void AddSettingRotation(string name, List<string> values, int defaultval) {
-		if (!settings.ContainsKey(name)) {
-			MPLSetting setting = new MPLSetting();
-			setting.name = name;
-			setting.values = values;
-			setting.type = SettingType.Rotation;
-			setting.defaultValue = defaultval % setting.values.Count; //doing the modulo for extra safety
-			settings.Add(name, setting);
-		} else {
-			MPLog.Log("Setting " + name + " was not added as it was already an initialized setting", LogLevel.Minor);
-		}
-	}
-	public static void AddSettingSlider(string name, float defaultval) {
-		if (!settings.ContainsKey(name)) {
-			MPLSetting setting = new MPLSetting();
-			setting.name = name;
-			setting.type = SettingType.Slider;
-			setting.defaultSliderValue = defaultval;
-			settings.Add(name, setting);
-		} else {
-			MPLog.Log("Setting " + name + " was not added as it was already an initialized setting", LogLevel.Minor);
-		}
-	}
-	public static void NextSettingsPage() {
-		if (settings.Count > settingsPage * 18 + 2) {
-			settingsPage++;
-			UpdateSettingsPage();
-		}
-	}
-	public static void PreviousSettingsPage() {
-		if (settingsPage > 0) {
-			settingsPage--;
-			UpdateSettingsPage();
-		}
-	}
-	public static void UpdateSettingsPage() {
-		int controlNum = 0;
-		foreach (MPLSetting setting in settings.Values) {
-			controlNum++;
-			if (controlNum < settingsPage * 18 + 2 && settingsPage != 0) {
-				setting.settingobj.SetActive(false);
-			} else if (controlNum < (settingsPage + 1) * 18 + 2 + ((settings.Count == settingsPage * 18 + 2) ? 1 : 0)) {
-				setting.settingobj.SetActive(true);
-			} else {
-				setting.settingobj.SetActive(false);
-			}
-		}
-		nextPage.gameObject.SetActive(false);
-		if (settingsPage == 0) {
-			previousPage.gameObject.SetActive(false);
-		} else {
-			previousPage.gameObject.SetActive(true);
-		}
-		if (settings.Count > (settingsPage + 1) * 18 + 2) {
-			nextPage.gameObject.SetActive(true);
-		} else {
-			nextPage.gameObject.SetActive(false);
-		}
-	}
+    public static bool SettingsSetUp = false;
+    public static Dictionary<string, MPLSetting> settings = new Dictionary<string, MPLSetting>();
+    public static int settingsPage = 0;
+    public static Transform previousPage;
+    public static Transform nextPage;
+
+    internal static bool folderActive = false;
+    internal static string currentFolder = "FolderSetup|Outside";
+    internal static string folderReturnKey = "FolderSetup|ReturnKey";
+
+    public static bool GetSettingToggle(string name)
+    {
+        if (!settings.ContainsKey(name))
+        {
+            MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
+            return false;
+        }
+        if (settings[name].type != SettingType.Toggle)
+        {
+            MPLog.Log("Setting " + name + " is a " + settings[name].type.ToString() + ", when a Toggle was asked for.", LogLevel.Major);
+            return false;
+        }
+        return PlayerPrefs.GetInt(name) > 0 ? true : false;
+    }
+    public static string GetSettingRotation(string name)
+    {
+        if (!settings.ContainsKey(name))
+        {
+            MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
+            return "";
+        }
+        if (settings[name].type != SettingType.Rotation)
+        {
+            MPLog.Log("Setting " + name + " is a " + settings[name].type.ToString() + ", when a Rotation was asked for.", LogLevel.Major);
+            return "";
+        }
+        return settings[name].values[PlayerPrefs.GetInt(name)];
+    }
+    public static float GetSettingSlider(string name)
+    {
+        if (!settings.ContainsKey(name))
+        {
+            MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
+            return 0;
+        }
+        if (settings[name].type != SettingType.Slider)
+        {
+            MPLog.Log("Setting " + name + " is a " + settings[name].type.ToString() + ", when a Slider was asked for.", LogLevel.Major);
+            return 0;
+        }
+        return PlayerPrefs.GetFloat(name);
+    }
+    public static string GetSettingTextBox(string name)
+    {
+        if (!settings.ContainsKey(name))
+        {
+            MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
+            return null;
+        }
+        if (settings[name].type != SettingType.TextField)
+        {
+            MPLog.Log("Setting " + name + " is a " + settings[name].type.ToString() + ", when a Text Input was asked for.", LogLevel.Major);
+            return null;
+        }
+        return PlayerPrefs.GetString(name);
+    }
+    public static List<string> GetSettingFolder(string name)
+    {
+        if (name == null)
+        {
+            MPLog.Log("Null setting name given!", LogLevel.Major);
+            return null;
+        }
+        if (!settings.ContainsKey(name))
+        {
+            MPLog.Log("Setting " + name + " does not exist!", LogLevel.Major);
+            return null;
+        }
+        if (settings[name].type != SettingType.Folder)
+        {
+            MPLog.Log("Setting " + name + " is a " + settings[name].type.ToString() + ", when a Folder was asked for.", LogLevel.Major);
+            return null;
+        }
+
+        UpdateFolders();
+        return settings[name].values;
+    }
+
+    public static void AddSettingToggle(string name, bool defaultval)
+    {
+        if (!settings.ContainsKey(name))
+        {
+            MPLSetting setting = new MPLSetting();
+            setting.name = name;
+            setting.key = name;
+            setting.type = SettingType.Toggle;
+            setting.defaultValue = defaultval ? 1 : 0;
+            settings.Add(name, setting);
+        }
+        else
+        {
+            MPLog.Log("Setting " + name + " was not added as it was already an initialized setting", LogLevel.Minor);
+        }
+    }
+    public static void AddSettingRotation(string name, List<string> values, int defaultval)
+    {
+        if (!settings.ContainsKey(name))
+        {
+            MPLSetting setting = new MPLSetting();
+            setting.name = name;
+            setting.key = name;
+            setting.values = values;
+            setting.type = SettingType.Rotation;
+            setting.defaultValue = defaultval % setting.values.Count; //doing the modulo for extra safety
+            settings.Add(name, setting);
+        }
+        else
+        {
+            MPLog.Log("Setting " + name + " was not added as it was already an initialized setting", LogLevel.Minor);
+        }
+    }
+    public static void AddSettingSlider(string name, float defaultval)
+    {
+        if (!settings.ContainsKey(name))
+        {
+            MPLSetting setting = new MPLSetting();
+            setting.name = name;
+            setting.key = name;
+            setting.type = SettingType.Slider;
+            setting.defaultSliderValue = defaultval;
+            settings.Add(name, setting);
+        }
+        else
+        {
+            MPLog.Log("Setting " + name + " was not added as it was already an initialized setting", LogLevel.Minor);
+        }
+    }
+    public static void AddSettingTextBox(string name, string placeholder = "Insert Text")
+    {
+        if (!settings.ContainsKey(name))
+        {
+            MPLSetting setting = new MPLSetting();
+            setting.name = name;
+            setting.key = name;
+            setting.type = SettingType.TextField;
+            settings.Add(name, setting);
+
+            setting.values = new List<string>();
+            setting.values.Add(placeholder);
+        }
+        else
+        {
+            MPLog.Log("Setting " + name + " was not added as it was already an initialized setting", LogLevel.Minor);
+        }
+    }
+    public static void AddSettingFolder(string name)
+    {
+        if (name == null)
+        {
+            MPLog.Log("Null setting name given!", LogLevel.Minor);
+            return;
+        }
+        if (settings.ContainsKey(name))
+        {
+            MPLog.Log("Folder '" + name + "' is already an initialized setting", LogLevel.Minor);
+            return;
+        }
+
+        MPLSetting setting = new MPLSetting();
+        setting.name = name;
+        setting.key = name;
+        setting.values = new List<string>();
+        setting.type = SettingType.Folder;
+
+        List<KeyValuePair<string, MPLSetting>> sorted = settings.ToList();
+        int folderCount = 0;
+        foreach (MPLSetting value in settings.Values) { if (value.type == SettingType.Folder) { folderCount++; } }
+        sorted.Insert(folderCount, new KeyValuePair<string, MPLSetting>(name, setting));
+        settings.Clear();
+        foreach (KeyValuePair<string, MPLSetting> pair in sorted) { settings.Add(pair.Key, pair.Value); }
+
+        if (!settings.ContainsKey(folderReturnKey))
+        {
+            MPLSetting returnBtn = new MPLSetting();
+            returnBtn.type = SettingType.Return;
+            settings.Add(folderReturnKey, returnBtn);
+        }
+    }
+
+    public static void NextSettingsPage()
+    {
+        if (settings.Count > settingsPage * 18 + 2)
+        {
+            settingsPage++;
+            UpdateSettingsPage();
+        }
+    }
+    public static void PreviousSettingsPage()
+    {
+        if (settingsPage > 0)
+        {
+            settingsPage--;
+            UpdateSettingsPage();
+        }
+    }
+    public static void UpdateSettingsPage()
+    {
+        if (settings.ContainsKey(folderReturnKey))
+        {
+            settings[folderReturnKey].settingobj.SetActive(false);
+            settings[folderReturnKey].settingobj.transform.SetAsLastSibling();
+        }
+
+        foreach (KeyValuePair<string, MPLSetting> pair in settings)
+        {
+            if (pair.Value.control.position.z < -35) { pair.Value.control.Translate(0, 0, (-5) - pair.Value.control.position.z); }
+            if (pair.Value.control.GetComponent<TextMeshProUGUI>() != null)
+            {
+                pair.Value.control.GetComponent<TextMeshProUGUI>().color = U.I.GetColor(UIColor.White);
+            }
+            pair.Value.settingobj.SetActive(false);
+        }
+        nextPage.GetChild(0).GetComponent<TextMeshProUGUI>().color = U.I.GetColor(UIColor.White);
+        previousPage.GetChild(0).GetComponent<TextMeshProUGUI>().color = U.I.GetColor(UIColor.White);
+
+        int controlNum = 0;
+
+        if (folderActive)
+        {
+            foreach (string path in settings[currentFolder].values)
+            {
+                string activeSettingFile = currentFolder + "/" + path;
+                if (settings.ContainsKey(activeSettingFile))
+                {
+                    if (controlNum < 18)
+                    {
+                        controlNum++;
+                        settings[activeSettingFile].settingobj.SetActive(true);
+                    }
+                }
+            }
+
+            settings[folderReturnKey].settingobj.SetActive(true);
+
+            previousPage.gameObject.SetActive(false);
+            nextPage.gameObject.SetActive(false);
+
+            foreach (MPLSetting option in settings.Values)
+            {
+                if (option.settingobj.activeSelf & S.I.optCtrl.content.activeSelf) 
+                { 
+                    S.I.optCtrl.btnCtrl.SetFocus(option.settingobj);
+                    if (option.type != SettingType.Return)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return;
+        }
+
+        List<MPLSetting> settingList = new List<MPLSetting>();
+        foreach (KeyValuePair<string, MPLSetting> pair in settings)
+        {
+            if (!pair.Value.inFolder & pair.Key != folderReturnKey)
+            {
+                settingList.Add(pair.Value);
+            }
+            else { pair.Value.settingobj.SetActive(false); }
+        }
+
+        foreach (MPLSetting setting in settingList)
+        {
+            controlNum++;
+            if (controlNum < settingsPage * 18 + 2 && settingsPage != 0)
+            {
+                setting.settingobj.SetActive(false);
+            }
+            else if (controlNum < (settingsPage + 1) * 18 + 2 + ((settings.Count == settingsPage * 18 + 2) ? 1 : 0))
+            {
+                setting.settingobj.SetActive(true);
+            }
+            else
+            {
+                setting.settingobj.SetActive(false);
+            }
+        }
+
+        if (currentFolder != "FolderSetup|Outside")
+        {
+            if (S.I.optCtrl.content)
+            {
+                S.I.optCtrl.btnCtrl.SetFocus(settings[currentFolder].settingobj);
+                currentFolder = "FolderSetup|Outside";
+            }
+        }
+        else
+        {
+            foreach (MPLSetting option in settings.Values)
+            {
+                if (option.settingobj.activeSelf & S.I.optCtrl.content.activeSelf) { S.I.optCtrl.btnCtrl.SetFocus(option.settingobj); break; }
+            }
+        }
+
+        nextPage.gameObject.SetActive(false);
+        if (settingsPage == 0)
+        {
+            previousPage.gameObject.SetActive(false);
+        }
+        else
+        {
+            previousPage.gameObject.SetActive(true);
+        }
+        if (settingList.Count > (settingsPage + 1) * 18 + 2)
+        {
+            nextPage.gameObject.SetActive(true);
+        }
+        else
+        {
+            nextPage.gameObject.SetActive(false);
+        }
+    }
+    internal static void UpdateFolders()
+    {
+        List<MPLSetting> trueFolders = new List<MPLSetting>();
+        foreach (MPLSetting setting in settings.Values)
+        {
+            if (setting.type == SettingType.Folder) 
+            { 
+                setting.values.Clear();
+                setting.control.GetComponent<TextMeshProUGUI>().text = setting.name;
+                trueFolders.Add(setting);
+            }
+        }
+
+        foreach (KeyValuePair<string, MPLSetting> pair in settings)
+        {
+            if (pair.Key.Contains("/"))
+            {
+                string folder = pair.Key.Substring(0, pair.Key.LastIndexOf("/"));
+                if (settings.ContainsKey(folder))
+                {
+                    if (settings[folder].type == SettingType.Folder)
+                    {
+                        if (pair.Value.name.StartsWith(folder + "/"))
+                        {
+                            pair.Value.name = pair.Value.name.Replace(folder + "/", string.Empty);
+                            pair.Value.control.GetComponent<TextMeshProUGUI>().text =
+                            pair.Value.control.GetComponent<TextMeshProUGUI>().text.Replace(folder + "/", string.Empty);
+                        }
+                        pair.Value.inFolder = true;
+
+                        if (!settings[folder].values.Contains(pair.Key.Replace(folder + "/", string.Empty)))
+                        {
+                            settings[folder].values.Add(pair.Key.Replace(folder + "/", string.Empty));
+                        }
+
+                        if (pair.Value.type == SettingType.TextField)
+                        {
+                            TextBoxDistanceUpdate(pair.Value);
+                        }
+
+                        if (pair.Value.type == SettingType.Slider)
+                        {
+                            pair.Value.control.GetComponent<TextMeshProUGUI>().name = pair.Value.name;
+                        }
+                    }
+                }
+            }
+        }
+
+        foreach (MPLSetting setting in trueFolders)
+        {
+            if (setting.values.Count > 0)
+            {
+                setting.control.GetComponent<TextMeshProUGUI>().text += " [ +" + setting.values.Count.ToString() + " ]";
+            }
+            else
+            {
+                setting.control.GetComponent<TextMeshProUGUI>().text += " []";
+            }
+        }
+    }
+    internal static void TextBoxDistanceUpdate(MPLSetting setting)
+    {
+        setting.control.GetComponent<TextMeshProUGUI>().ForceMeshUpdate();
+
+        string _TextBoxText = setting.control.GetComponent<TextMeshProUGUI>().text;
+        float _TextBoxSize1 = setting.control.GetComponent<TextMeshProUGUI>().GetTextInfo(_TextBoxText).characterInfo[0].topLeft.x;
+        float _TextBoxSize2 = setting.control.GetComponent<TextMeshProUGUI>().GetTextInfo(_TextBoxText).characterInfo[_TextBoxText.Length - 1].bottomRight.x;
+        float _TextBoxDis = setting.control.GetComponent<TextMeshProUGUI>().transform.position.x + (_TextBoxSize2 - _TextBoxSize1 + 2)
+                            - setting.control.GetComponent<NavTextfield>().transform.GetChild(0).position.x;
+
+        setting.control.GetComponent<NavTextfield>().transform.GetChild(0).Translate(_TextBoxDis, 0, 0);
+    }
 }
 
 [HarmonyPatch(typeof(OptionCtrl))]
 [HarmonyPatch("Open")]
 class SettingsPatch
 {
-	static void Prefix(OptionCtrl __instance) {
-		if (MPLCustomSettings.SettingsSetUp == false) {
-			var button = Object.Instantiate(__instance.navButtonGrid.GetChild(1), __instance.navButtonGrid);
-			button.GetComponent<UIButton>().tmpText.text = "MODS";
-			button.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "MODS";
+    static void Prefix(OptionCtrl __instance)
+    {
+        if (MPLCustomSettings.SettingsSetUp == false)
+        {
+            var button = Object.Instantiate(__instance.navButtonGrid.GetChild(1), __instance.navButtonGrid);
+            button.GetComponent<UIButton>().tmpText.text = "MODS";
+            button.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "MODS";
+            if (button.parent.childCount >= 4) { button.SetSiblingIndex(3); }
 
-			var modSettingsMenu = Object.Instantiate(__instance.settingsPane.gameObject);
-			modSettingsMenu.transform.position = __instance.settingsPane.transform.position;
-			modSettingsMenu.transform.SetParent(__instance.settingsPane.transform.parent);
-			var settingsPane = modSettingsMenu.GetComponent<SettingsPane>();
-			GameObject _content = settingsPane.content;
-			SlideBody _slideBody = settingsPane.slideBody;
-			Animator _anim = settingsPane.anim;
-			TMP_Text _title = settingsPane.title;
-			UIButton _defaultButton = settingsPane.defaultButton;
-			UIButton _backButton = settingsPane.backButton;
-			UIButton _originButton = settingsPane.originButton;
-			Object.DestroyImmediate(settingsPane);
-			modSettingsMenu.AddComponent<NavPanel>();
-			var newPane = modSettingsMenu.GetComponent<NavPanel>();
-			newPane.content = _content;
-			newPane.slideBody = _slideBody;
-			newPane.anim = _anim;
-			newPane.title = _title;
-			newPane.defaultButton = _defaultButton;
-			newPane.backButton = _backButton;
-			newPane.originButton = _originButton;
+            var modSettingsMenu = Object.Instantiate(__instance.settingsPane.gameObject);
+            modSettingsMenu.transform.position = __instance.settingsPane.transform.position;
+            modSettingsMenu.transform.SetParent(__instance.settingsPane.transform.parent);
+            var settingsPane = modSettingsMenu.GetComponent<SettingsPane>();
+            GameObject _content = settingsPane.content;
+            SlideBody _slideBody = settingsPane.slideBody;
+            Animator _anim = settingsPane.anim;
+            TMP_Text _title = settingsPane.title;
+            UIButton _defaultButton = settingsPane.defaultButton;
+            UIButton _backButton = settingsPane.backButton;
+            UIButton _originButton = settingsPane.originButton;
+            Object.DestroyImmediate(settingsPane);
+            modSettingsMenu.AddComponent<NavPanel>();
+            var newPane = modSettingsMenu.GetComponent<NavPanel>();
+            newPane.content = _content;
+            newPane.slideBody = _slideBody;
+            newPane.anim = _anim;
+            newPane.title = _title;
+            newPane.defaultButton = _defaultButton;
+            newPane.backButton = _backButton;
+            newPane.originButton = _originButton;
 
-			Object.DestroyImmediate(button.GetComponent<Button>());
-			{
-				EventTrigger.Entry entry = new EventTrigger.Entry();
-				entry.eventID = EventTriggerType.PointerClick;
-				entry.callback.AddListener((data) => { S.I.optCtrl.OpenPanel(modSettingsMenu.GetComponent<NavPanel>()); });
-				EventTrigger trigger = button.gameObject.AddComponent<EventTrigger>();
-				trigger.triggers.Add(entry);
-				trigger.enabled = false;
-			}
+            Object.DestroyImmediate(button.GetComponent<Button>());
+            {
+                EventTrigger.Entry entry = new EventTrigger.Entry();
+                entry.eventID = EventTriggerType.PointerClick;
+                entry.callback.AddListener((data) => {
+                    S.I.optCtrl.OpenPanel(modSettingsMenu.GetComponent<NavPanel>());
+                });
+                EventTrigger trigger = button.gameObject.AddComponent<EventTrigger>();
+                trigger.triggers.Add(entry);
+                trigger.enabled = false;
+            }
 
-			//button.GetComponent<UIButton>().onAcceptPress.RemoveAllListeners();
+            //button.GetComponent<UIButton>().onAcceptPress.RemoveAllListeners();
 
-			var navPanelBackground = modSettingsMenu.transform.GetChild(0).GetChild(0);
-			var navPanelButtons = modSettingsMenu.transform.GetChild(0).GetChild(1);
-			var navPanelTitle = modSettingsMenu.transform.GetChild(0).GetChild(2);
-			var navPanelExit = modSettingsMenu.transform.GetChild(0).GetChild(3);
+            var navPanelBackground = modSettingsMenu.transform.GetChild(0).GetChild(0);
+            var navPanelButtons = modSettingsMenu.transform.GetChild(0).GetChild(1);
+            var navPanelTitle = modSettingsMenu.transform.GetChild(0).GetChild(2);
+            var navPanelExit = modSettingsMenu.transform.GetChild(0).GetChild(3);
 
-			navPanelTitle.GetComponent<TextMeshProUGUI>().text = "MOD SETTINGS";
-			navPanelTitle.GetComponent<I2.Loc.Localize>().Term = "MOD SETTINGS";
+            navPanelTitle.GetComponent<TextMeshProUGUI>().text = "MOD SETTINGS";
+            navPanelTitle.GetComponent<I2.Loc.Localize>().Term = "MOD SETTINGS";
 
-			for (int i = 0; i < navPanelButtons.transform.childCount; i++) {
-				navPanelButtons.transform.GetChild(i).gameObject.SetActive(false);
-			}
+            for (int i = 0; i < navPanelButtons.transform.childCount; i++)
+            {
+                navPanelButtons.transform.GetChild(i).gameObject.SetActive(false);
+            }
 
-			GameObject PrevButton = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
-			PrevButton.SetActive(true);
-			PrevButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().text = "Previous Page";
-			PrevButton.transform.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "Previous Page";
-			Object.DestroyImmediate(PrevButton.GetComponent<Button>());
-			{
-				EventTrigger.Entry entry = new EventTrigger.Entry();
-				entry.eventID = EventTriggerType.PointerClick;
-				entry.callback.AddListener((data) => { MPLCustomSettings.PreviousSettingsPage(); });
-				EventTrigger trigger = PrevButton.AddComponent<EventTrigger>();
-				trigger.triggers.Add(entry);
-				trigger.enabled = false;
-			}
-			MPLCustomSettings.previousPage = PrevButton.transform;
+            GameObject PrevButton = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
+            PrevButton.SetActive(true);
+            PrevButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().text = "Previous Page";
+            PrevButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().alignment = TextAlignmentOptions.Left;
+            PrevButton.transform.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "Previous Page";
+            Object.DestroyImmediate(PrevButton.GetComponent<Button>());
+            {
+                EventTrigger.Entry entry = new EventTrigger.Entry();
+                entry.eventID = EventTriggerType.PointerClick;
+                entry.callback.AddListener((data) => { MPLCustomSettings.PreviousSettingsPage(); });
+                EventTrigger trigger = PrevButton.AddComponent<EventTrigger>();
+                trigger.triggers.Add(entry);
+                trigger.enabled = false;
+            }
+            MPLCustomSettings.previousPage = PrevButton.transform;
 
-			foreach (MPLSetting setting in MPLCustomSettings.settings.Values) {
-				switch (setting.type) {
-					case SettingType.Toggle:
-						if (PlayerPrefs.HasKey(setting.name)) {
-							setting.activeValue = PlayerPrefs.GetInt(setting.name);
-						} else {
-							setting.activeValue = setting.defaultValue;
-						}
-						setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
-						setting.settingobj.SetActive(true);
-						setting.control = setting.settingobj.transform.GetChild(0);
-						setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + (setting.activeValue > 0 ? "True" : "False");
-						setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
-						Object.DestroyImmediate(setting.settingobj.GetComponent<Button>()); 
-						{
-							EventTrigger.Entry entry = new EventTrigger.Entry();
-							entry.eventID = EventTriggerType.PointerClick;
-							entry.callback.AddListener((data) => {
-								setting.activeValue = setting.activeValue > 0 ? 0 : 1;
-								PlayerPrefs.SetInt(setting.name, setting.activeValue);
-								setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + (setting.activeValue > 0 ? "True" : "False");
-							});
-							EventTrigger trigger = setting.settingobj.AddComponent<EventTrigger>();
-							trigger.triggers.Add(entry);
-							trigger.enabled = false;
-						}
-						break;
-					case SettingType.Rotation:
-						if (PlayerPrefs.HasKey(setting.name)) {
-							setting.activeValue = PlayerPrefs.GetInt(setting.name);
-						} else {
-							setting.activeValue = setting.defaultValue;
-						}
-						setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
-						setting.settingobj.SetActive(true);
-						setting.control = setting.settingobj.transform.GetChild(0);
-						setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + setting.values[setting.activeValue];
-						setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
-						Object.DestroyImmediate(setting.settingobj.GetComponent<Button>()); 
-						{
-							EventTrigger.Entry entry = new EventTrigger.Entry();
-							entry.eventID = EventTriggerType.PointerClick;
-							entry.callback.AddListener((data) => {
-								setting.activeValue = (setting.activeValue + 1 < setting.values.Count ? setting.activeValue + 1 : 0);
-								PlayerPrefs.SetInt(setting.name, setting.activeValue);
-								setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + setting.values[setting.activeValue];
-							});
-							EventTrigger trigger = setting.settingobj.AddComponent<EventTrigger>();
-							trigger.triggers.Add(entry);
-							trigger.enabled = false;
-						}
-						break;
-					case SettingType.Slider:
-						setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(5).gameObject, navPanelButtons.transform);
-						setting.settingobj.SetActive(true);
-						setting.settingobj.transform.name = setting.name;
-						setting.control = setting.settingobj.transform.GetChild(3);
-						setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
+            foreach (MPLSetting setting in MPLCustomSettings.settings.Values)
+            {
+                switch (setting.type)
+                {
+                    case SettingType.Toggle:
+                        if (PlayerPrefs.HasKey(setting.key))
+                        {
+                            setting.activeValue = PlayerPrefs.GetInt(setting.key);
+                        }
+                        else
+                        {
+                            setting.activeValue = setting.defaultValue;
+                        }
+                        setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
+                        setting.settingobj.SetActive(true);
+                        setting.control = setting.settingobj.transform.GetChild(0);
+                        setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + (setting.activeValue > 0 ? "True" : "False");
+                        setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
+                        Object.DestroyImmediate(setting.settingobj.GetComponent<Button>());
+                        {
+                            EventTrigger.Entry entry = new EventTrigger.Entry();
+                            entry.eventID = EventTriggerType.PointerClick;
+                            entry.callback.AddListener((data) => {
+                                setting.activeValue = setting.activeValue > 0 ? 0 : 1;
+                                PlayerPrefs.SetInt(setting.key, setting.activeValue);
+                                setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + (setting.activeValue > 0 ? "True" : "False");
+                            });
+                            EventTrigger trigger = setting.settingobj.AddComponent<EventTrigger>();
+                            trigger.triggers.Add(entry);
+                            trigger.enabled = false;
+                        }
+                        break;
+                    case SettingType.Rotation:
+                        if (PlayerPrefs.HasKey(setting.key))
+                        {
+                            setting.activeValue = PlayerPrefs.GetInt(setting.key);
+                        }
+                        else
+                        {
+                            setting.activeValue = setting.defaultValue;
+                        }
+                        setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
+                        setting.settingobj.SetActive(true);
+                        setting.control = setting.settingobj.transform.GetChild(0);
+                        setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + setting.values[setting.activeValue];
+                        setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
+                        Object.DestroyImmediate(setting.settingobj.GetComponent<Button>());
+                        {
+                            EventTrigger.Entry entry = new EventTrigger.Entry();
+                            entry.eventID = EventTriggerType.PointerClick;
+                            entry.callback.AddListener((data) => {
+                                setting.activeValue = (setting.activeValue + 1 < setting.values.Count ? setting.activeValue + 1 : 0);
+                                PlayerPrefs.SetInt(setting.key, setting.activeValue);
+                                setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + setting.values[setting.activeValue];
+                            });
+                            EventTrigger trigger = setting.settingobj.AddComponent<EventTrigger>();
+                            trigger.triggers.Add(entry);
+                            trigger.enabled = false;
+                        }
+                        break;
+                    case SettingType.Slider:
+                        setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(5).gameObject, navPanelButtons.transform);
+                        setting.settingobj.SetActive(true);
+                        setting.settingobj.transform.name = setting.key;
+                        setting.control = setting.settingobj.transform.GetChild(3);
+                        setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
+                        setting.control.GetComponent<TextMeshProUGUI>().name = setting.name;
 
-						if (PlayerPrefs.HasKey(setting.name)) {
-							setting.settingobj.GetComponent<Slider>().value = PlayerPrefs.GetFloat(setting.name);
-						} else {
-							setting.settingobj.GetComponent<Slider>().value = setting.defaultSliderValue;
-						}
-						PowerMonoBehavior.sliders.Add(setting.settingobj.transform);
-						break;
-				}
-			}
+                        if (PlayerPrefs.HasKey(setting.key))
+                        {
+                            setting.settingobj.GetComponent<Slider>().value = PlayerPrefs.GetFloat(setting.key);
+                        }
+                        else
+                        {
+                            setting.settingobj.GetComponent<Slider>().value = setting.defaultSliderValue;
+                        }
 
-			GameObject NextButton = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
-			NextButton.SetActive(true);
-			NextButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().text = "Next Page";
-			NextButton.transform.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "Next Page";
-			Object.DestroyImmediate(NextButton.GetComponent<Button>());
-			{
-				EventTrigger.Entry entry = new EventTrigger.Entry();
-				entry.eventID = EventTriggerType.PointerClick;
-				entry.callback.AddListener((data) => { MPLCustomSettings.NextSettingsPage(); });
-				EventTrigger trigger = NextButton.AddComponent<EventTrigger>();
-				trigger.triggers.Add(entry);
-				trigger.enabled = false;
-			}
-			MPLCustomSettings.nextPage = NextButton.transform;
+                        setting.control.GetComponent<TextMeshProUGUI>().transform.Translate(8, 0, 0);
 
-			Object.DestroyImmediate(navPanelExit.GetComponent<Button>());
-			navPanelExit.gameObject.AddComponent<Button>();
-			navPanelExit.GetComponent<Button>().onClick.AddListener(() => { S.I.optCtrl.ClosePanel(modSettingsMenu.GetComponent<NavPanel>()); });
-			Traverse.Create(navPanelExit.GetComponent<UIButton>()).Field("button").SetValue(navPanelExit.GetComponent<Button>());
+                        PowerMonoBehavior.sliders.Add(setting.settingobj.transform);
+                        break;
+                    case SettingType.TextField:
 
-			MPLCustomSettings.UpdateSettingsPage();
+                        Transform InputFieldRef = S.I.heCtrl.content.transform.Find("SeedField");
+                        TextMeshProUGUI InputFieldGUIRef = navPanelButtons.transform.GetChild(0).GetChild(0).GetComponent<TextMeshProUGUI>();
 
-			MPLCustomSettings.SettingsSetUp = true;
-		}
-	}
+                        NavTextfield TextBoxInputRef = S.I.heCtrl.content.transform.Find("SeedField").GetComponent<NavTextfield>();
+
+                        setting.settingobj = Object.Instantiate(InputFieldRef.gameObject, navPanelButtons.transform);
+                        setting.settingobj.SetActive(true);
+
+                        setting.control = setting.settingobj.transform;
+                        setting.control.GetComponent<NavTextfield>().btnCtrl = S.I.optCtrl.btnCtrl;
+                        setting.control.GetComponent<NavTextfield>().name = "MoreLuaPowerSettingsNavTextField" + setting.key;
+
+                        Object.DestroyImmediate(setting.settingobj.GetComponent<Image>());
+                        setting.settingobj.AddComponent<TextMeshProUGUI>();
+
+                        setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + " :";
+                        setting.control.GetComponent<TextMeshProUGUI>().fontSize = InputFieldGUIRef.fontSize;
+                        setting.control.GetComponent<TextMeshProUGUI>().font = InputFieldGUIRef.font;
+
+                        setting.control.GetComponent<NavTextfield>().navList = PrevButton.GetComponent<NavButton>().navList;
+                        setting.control.GetComponent<NavTextfield>().useParentTransformNav = true;
+                        setting.control.GetComponent<NavTextfield>().transform.GetChild(0).GetChild(0).Translate(0, -1f, 0);
+
+                        setting.control.GetComponent<TMP_InputField>().textComponent.fontSize = InputFieldGUIRef.fontSize;
+                        setting.control.GetComponent<TMP_InputField>().textComponent.color = new Color(0.8f, 0.8f, 0.8f);
+                        setting.control.GetComponent<TMP_InputField>().textComponent.font = InputFieldGUIRef.font;
+                        setting.control.GetComponent<TMP_InputField>().textComponent.alignment = TextAlignmentOptions.Left;
+                        setting.control.GetComponent<TMP_InputField>().placeholder.GetComponent<TextMeshProUGUI>().fontStyle = FontStyles.Normal;
+                        setting.control.GetComponent<TMP_InputField>().placeholder.GetComponent<TextMeshProUGUI>().fontSize = InputFieldGUIRef.fontSize;
+                        setting.control.GetComponent<TMP_InputField>().placeholder.GetComponent<TextMeshProUGUI>().SetText(setting.values[0]);
+                        setting.control.GetComponent<TMP_InputField>().placeholder.GetComponent<I2.Loc.Localize>().Term = "";
+
+                        setting.control.GetComponent<TMP_InputField>().characterLimit = 14;
+
+                        MPLCustomSettings.TextBoxDistanceUpdate(setting);
+
+                        if (PlayerPrefs.HasKey(setting.key))
+                        {
+                            setting.control.GetComponent<TMP_InputField>().text = PlayerPrefs.GetString(setting.key);
+                        }
+                        else
+                        {
+                            setting.control.GetComponent<TMP_InputField>().text = string.Empty;
+                        }
+
+                        break;
+
+                    //setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
+                    //setting.settingobj = Object.Instantiate(streamPane.GetChild(0).GetChild(3).gameObject, navPanelButtons.transform);
+                    //buttonNavText.inputField = Object.Instantiate(streamPane.GetChild(0).GetChild(3).GetComponent<NavTextfield>().inputField, setting.control);
+                    //setting.control = Object.Instantiate(S.I.heCtrl.seedInput, setting.settingobj.transform).transform;
+                    //setting.control.gameObject.AddComponent<TMP_InputField>();
+
+                    case SettingType.Folder:
+                        setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
+                        setting.settingobj.SetActive(true);
+                        setting.control = setting.settingobj.transform.GetChild(0);
+                        setting.control.GetComponent<TextMeshProUGUI>().text = setting.name;
+
+                        setting.control.GetComponent<TextMeshProUGUI>().fontStyle = FontStyles.Bold;
+                        setting.control.GetComponent<TextMeshProUGUI>().alignment = TextAlignmentOptions.TopLeft;
+
+                        setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
+
+                        Object.DestroyImmediate(setting.settingobj.GetComponent<Button>());
+                        {
+                            EventTrigger.Entry entry = new EventTrigger.Entry();
+                            entry.eventID = EventTriggerType.PointerClick;
+                            entry.callback.AddListener((data) => {
+                                MPLCustomSettings.folderActive = true;
+                                MPLCustomSettings.currentFolder = setting.key;
+                                MPLCustomSettings.UpdateSettingsPage();
+                            });
+
+                            EventTrigger trigger = setting.settingobj.AddComponent<EventTrigger>();
+                            trigger.triggers.Add(entry);
+                            trigger.enabled = false;
+                        }
+
+                        break;
+                    case SettingType.Return:
+                        setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
+                        setting.settingobj.SetActive(true);
+                        setting.control = setting.settingobj.transform.GetChild(0);
+                        setting.control.GetComponent<TextMeshProUGUI>().text = "Return?";
+                        setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
+
+                        setting.control.GetComponent<TextMeshProUGUI>().fontStyle = FontStyles.Italic;
+
+                        Object.DestroyImmediate(setting.settingobj.GetComponent<Button>());
+                        {
+                            EventTrigger.Entry entry = new EventTrigger.Entry();
+                            entry.eventID = EventTriggerType.PointerClick;
+                            entry.callback.AddListener((data) => {
+                                MPLCustomSettings.folderActive = false;
+                                if (MPLCustomSettings.currentFolder.Contains("/"))
+                                {
+                                    if (MPLCustomSettings.settings.ContainsKey( MPLCustomSettings.currentFolder.Substring(0, MPLCustomSettings.currentFolder.LastIndexOf("/") ) )
+                                    )
+                                    {
+                                        if ( MPLCustomSettings.settings[MPLCustomSettings.currentFolder.Substring(0, MPLCustomSettings.currentFolder.LastIndexOf("/") )].type == SettingType.Folder )
+                                        {
+                                            MPLCustomSettings.folderActive = true;
+                                            MPLCustomSettings.currentFolder = MPLCustomSettings.currentFolder.Substring(0, MPLCustomSettings.currentFolder.LastIndexOf("/"));
+                                        }
+                                    }
+                                }
+                                MPLCustomSettings.UpdateSettingsPage();
+                            });
+
+                            EventTrigger trigger = setting.settingobj.AddComponent<EventTrigger>();
+                            trigger.triggers.Add(entry);
+                            trigger.enabled = false;
+                        }
+                        break;
+                }
+                if (setting.type != SettingType.Folder & setting.control.GetComponent<TextMeshProUGUI>() != null)
+                {
+                    setting.control.GetComponent<TextMeshProUGUI>().alignment = TextAlignmentOptions.Left;
+                }
+            }
+
+            GameObject NextButton = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
+            NextButton.SetActive(true);
+            NextButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().text = "Next Page";
+            NextButton.transform.GetChild(0).GetComponent<I2.Loc.Localize>().Term = "Next Page";
+            NextButton.transform.GetChild(0).GetComponent<TextMeshProUGUI>().alignment = TextAlignmentOptions.Left;
+            Object.DestroyImmediate(NextButton.GetComponent<Button>());
+            {
+                EventTrigger.Entry entry = new EventTrigger.Entry();
+                entry.eventID = EventTriggerType.PointerClick;
+                entry.callback.AddListener((data) => { MPLCustomSettings.NextSettingsPage(); });
+                EventTrigger trigger = NextButton.AddComponent<EventTrigger>();
+                trigger.triggers.Add(entry);
+                trigger.enabled = false;
+            }
+            MPLCustomSettings.nextPage = NextButton.transform;
+
+            Object.DestroyImmediate(navPanelExit.GetComponent<Button>());
+            navPanelExit.gameObject.AddComponent<Button>();
+            navPanelExit.GetComponent<Button>().onClick.AddListener(() => { S.I.optCtrl.ClosePanel(modSettingsMenu.GetComponent<NavPanel>()); });
+            Traverse.Create(navPanelExit.GetComponent<UIButton>()).Field("button").SetValue(navPanelExit.GetComponent<Button>());
+
+            MPLCustomSettings.UpdateFolders();
+            MPLCustomSettings.UpdateSettingsPage();
+
+            MPLCustomSettings.SettingsSetUp = true;
+        }
+    }
+
+    [HarmonyPatch(typeof(NavTextfield))]
+    [HarmonyPatch(nameof(NavTextfield.Focus))]
+    [HarmonyPostfix]
+    private static void NavFieldFixIntro(NavTextfield __instance)
+    {
+        if (__instance.name.StartsWith("MoreLuaPowerSettingsNavTextField"))
+        {
+            __instance.canvasGroup.alpha = 1f;
+            if (__instance.GetComponent<TextMeshProUGUI>() != null)
+            {
+                __instance.GetComponent<TextMeshProUGUI>().color = U.I.GetColor(UIColor.Pink);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(NavTextfield))]
+    [HarmonyPatch(nameof(NavTextfield.UnFocus))]
+    [HarmonyPostfix]
+    private static void NavFieldFixOutro(NavTextfield __instance)
+    {
+        if (__instance.name.StartsWith("MoreLuaPowerSettingsNavTextField"))
+        {
+            __instance.canvasGroup.alpha = 1f;
+            if (__instance.GetComponent<TextMeshProUGUI>() != null)
+            {
+                __instance.GetComponent<TextMeshProUGUI>().color = U.I.GetColor(UIColor.White);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(NavTextfield))]
+    [HarmonyPatch(nameof(NavTextfield.OnEndEdit))]
+    [HarmonyPostfix]
+    private static void NavFieldEndEditSave(NavTextfield __instance)
+    {
+        if (__instance.name.StartsWith("MoreLuaPowerSettingsNavTextField"))
+        {
+            if (__instance.GetComponent<TMP_InputField>() != null)
+            {
+                PlayerPrefs.SetString(
+                    __instance.name.Substring("MoreLuaPowerSettingsNavTextField".Length),
+                    __instance.GetComponent<TMP_InputField>().text
+                    );
+            }
+        }
+    }
 }

--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -462,21 +462,25 @@ public static class MPLCustomSettings
     internal static void SortFolders()
     {
         List<KeyValuePair<string, MPLSetting>> sortedSettings = settings.ToList();
-        sortedSettings.Sort((x, y) => SortFoldersX(x.Value, y.Value));
+        sortedSettings.Sort((x, y) => SortFoldersX(x.Value, y.Value, settings.ToList()));
         settings.Clear();
         foreach (KeyValuePair<string, MPLSetting> pair in sortedSettings)
         {
             settings.Add(pair.Key, pair.Value);
         }
     }
-    internal static int SortFoldersX(MPLSetting x, MPLSetting y)
+    internal static int SortFoldersX(MPLSetting x, MPLSetting y, List<KeyValuePair<string, MPLSetting>> oldList)
     {
-        if (x.type == y.type) { return 0; }
-
         if (x.type == SettingType.Return) { return 1; }
         if (y.type == SettingType.Return) { return -1; }
 
-        if (x.type != SettingType.Folder & y.type != SettingType.Folder) { return 0; }
+        if ((x.type != SettingType.Folder & y.type != SettingType.Folder) || x.type == y.type) 
+        {
+            int xpos = oldList.FindIndex(a => a.Value == x);
+            int ypos = oldList.FindIndex(a => a.Value == y);
+            if (xpos < ypos) { return -1; }
+            return 1; 
+        }
 
         if (x.type == SettingType.Folder) { return -1; }
         return 1;

--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -221,6 +221,7 @@ public static class MPLCustomSettings
         {
             MPLSetting returnBtn = new MPLSetting();
             returnBtn.type = SettingType.Return;
+            returnBtn.values = new List<string>(1) { string.Empty };
             settings.Add(folderReturnKey, returnBtn);
         }
     }
@@ -283,14 +284,31 @@ public static class MPLCustomSettings
             previousPage.gameObject.SetActive(false);
             nextPage.gameObject.SetActive(false);
 
-            foreach (MPLSetting option in settings.Values)
+            string previousFolder = settings[folderReturnKey].values[0];
+            if (previousFolder.StartsWith(currentFolder) & S.I.optCtrl.content.activeSelf)
             {
-                if (option.settingobj.activeSelf & S.I.optCtrl.content.activeSelf) 
-                { 
-                    S.I.optCtrl.btnCtrl.SetFocus(option.settingobj);
-                    if (option.type != SettingType.Return)
+                if ( settings[currentFolder].values.Contains(previousFolder.Replace(currentFolder + "/", string.Empty)) )
+                {
+                    S.I.optCtrl.btnCtrl.SetFocus(settings[previousFolder].settingobj);
+                    return;
+                }
+            }
+
+            if (S.I.optCtrl.content.activeSelf)
+            {
+                if (settings[currentFolder].values.Count == 0)
+                {
+                    S.I.optCtrl.btnCtrl.SetFocus(settings[folderReturnKey].settingobj);
+                }
+                else
+                {
+                    foreach (MPLSetting option in settings.Values)
                     {
-                        break;
+                        if (option.type != SettingType.Return & option.settingobj.activeSelf)
+                        {
+                            S.I.optCtrl.btnCtrl.SetFocus(option.settingobj);
+                            break;
+                        }
                     }
                 }
             }
@@ -641,13 +659,6 @@ class SettingsPatch
                         }
 
                         break;
-
-                    //setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
-                    //setting.settingobj = Object.Instantiate(streamPane.GetChild(0).GetChild(3).gameObject, navPanelButtons.transform);
-                    //buttonNavText.inputField = Object.Instantiate(streamPane.GetChild(0).GetChild(3).GetComponent<NavTextfield>().inputField, setting.control);
-                    //setting.control = Object.Instantiate(S.I.heCtrl.seedInput, setting.settingobj.transform).transform;
-                    //setting.control.gameObject.AddComponent<TMP_InputField>();
-
                     case SettingType.Folder:
                         setting.settingobj = Object.Instantiate(navPanelButtons.transform.GetChild(0).gameObject, navPanelButtons.transform);
                         setting.settingobj.SetActive(true);
@@ -699,6 +710,7 @@ class SettingsPatch
                                         if ( MPLCustomSettings.settings[MPLCustomSettings.currentFolder.Substring(0, MPLCustomSettings.currentFolder.LastIndexOf("/") )].type == SettingType.Folder )
                                         {
                                             MPLCustomSettings.folderActive = true;
+                                            setting.values[0] = MPLCustomSettings.currentFolder;
                                             MPLCustomSettings.currentFolder = MPLCustomSettings.currentFolder.Substring(0, MPLCustomSettings.currentFolder.LastIndexOf("/"));
                                         }
                                     }

--- a/Lua/GlobalLuaFunctions.cs
+++ b/Lua/GlobalLuaFunctions.cs
@@ -80,7 +80,7 @@ class MoreLuaPower_GlobalLuaFunctions
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddCustomAchievement"] = (Action<string, string, string, bool>)LuaPowerAchievements.APIV.AddCustomAchievement;
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["UnlockCustomAchievement"] = (Action<string, int>)LuaPowerAchievements.APIV.UnlockCustomAchievement;
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["CreateDrop"] = (Action<List<ItemObject>>)LuaPowerCustomDrops.CreateDrop;
-	Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddEdenGossip"] = (Action<string, string, string, string>)EdenGossip_AdditiveLines.Gossip_Data.AddEdenGossip;
+	    Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddEdenGossip"] = (Action<string, string, string, string>)EdenGossip_AdditiveLines.Gossip_Data.AddEdenGossip;
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["RemoveEdenGossip"] = (Action<string, string, string, string>)EdenGossip_AdditiveLines.Gossip_Data.RemoveEdenGossip;
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["GetEdenGossip"] = (Func<string, string, string, List<string>>)EdenGossip_AdditiveLines.Gossip_Data.GetEdenGossip;
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["GetSettingToggle"] = (Func<string, bool>)MPLCustomSettings.GetSettingToggle;
@@ -89,11 +89,13 @@ class MoreLuaPower_GlobalLuaFunctions
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingToggle"] = (Action<string, bool>)MPLCustomSettings.AddSettingToggle;
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingRotation"] = (Action<string, List<string>, int>)MPLCustomSettings.AddSettingRotation;
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingSlider"] = (Action<string, float>)MPLCustomSettings.AddSettingSlider;
-	Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingFolder"] = (Action<string>)MPLCustomSettings.AddSettingFolder;
-	Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["GetSettingFolder"] = (Func<string, List<string>>)MPLCustomSettings.GetSettingFolder;
-	Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingTextBox"] = (Action<string, string>)MPLCustomSettings.AddSettingTextBox;
-	Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["GetSettingTextBox"] = (Func<string, string>)MPLCustomSettings.GetSettingTextBox;
-	}
+	    Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingFolder"] = (Action<string>)MPLCustomSettings.AddSettingFolder;
+	    Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["GetSettingFolder"] = (Func<string, List<string>>)MPLCustomSettings.GetSettingFolder;
+	    Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingTextBox"] = (Action<string, string>)MPLCustomSettings.AddSettingTextBox;
+	    Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["GetSettingTextBox"] = (Func<string, string>)MPLCustomSettings.GetSettingTextBox;
+        Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingButton"] = (Action<string, List<string>>)MPLCustomSettings.AddSettingButton;
+        Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["EditSettingButton"] = (Action<string, List<string>>)MPLCustomSettings.EditSettingButton;
+    }
 }
 
 [HarmonyPatch(typeof(EffectActions))]

--- a/Lua/GlobalLuaFunctions.cs
+++ b/Lua/GlobalLuaFunctions.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using MoonSharp.Interpreter;
 using System;
 using System.Collections;
@@ -89,6 +89,10 @@ class MoreLuaPower_GlobalLuaFunctions
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingToggle"] = (Action<string, bool>)MPLCustomSettings.AddSettingToggle;
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingRotation"] = (Action<string, List<string>, int>)MPLCustomSettings.AddSettingRotation;
         Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingSlider"] = (Action<string, float>)MPLCustomSettings.AddSettingSlider;
+	Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingFolder"] = (Action<string>)MPLCustomSettings.AddSettingFolder;
+	Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["GetSettingFolder"] = (Func<string, List<string>>)MPLCustomSettings.GetSettingFolder;
+	Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["AddSettingTextBox"] = (Action<string, string>)MPLCustomSettings.AddSettingTextBox;
+	Traverse.Create(Traverse.Create<EffectActions>().Field("_Instance").GetValue<EffectActions>()).Field("myLuaScript").GetValue<Script>().Globals["GetSettingTextBox"] = (Func<string, string>)MPLCustomSettings.GetSettingTextBox;
 	}
 }
 

--- a/Misc/PowerMonoBehavior.cs
+++ b/Misc/PowerMonoBehavior.cs
@@ -18,17 +18,34 @@ public class PowerMonoBehavior : MonoBehaviour
         for (int i = 0; i < UpdateScripts.Count; i++) {
             S.I.mainCtrl.StartCoroutine(MoreLuaPower_FunctionHelper.EffectRoutine(UpdateBaseScripts[i].CreateCoroutine(UpdateScripts[i])));
         }
-        foreach(Transform slider in sliders) {
-            if (slider == null) { 
-                sliders.Remove(slider);
-                continue;
-            }
-            string temp = slider.GetChild(3).GetComponent<TextMeshProUGUI>().text;
-			slider.GetChild(3).GetComponent<TextMeshProUGUI>().text = string.Format("{0}: {1}", slider.name, slider.GetComponent<Slider>().value) + "%";
-            if (temp != slider.GetChild(3).GetComponent<TextMeshProUGUI>().text) {
-                PlayerPrefs.SetFloat(slider.name, slider.GetComponent<Slider>().value);
-            }
-		}
+
+        foreach(Transform slider in sliders) 
+	{
+  		if (slider == null) 
+    		{ 
+     			sliders.Remove(slider);
+     			continue;
+  		}
+
+  		float sliderVal = slider.GetComponent<Slider>().value;
+  		string sliderKey = slider.name;
+  		if (PlayerPrefs.HasKey(sliderKey))
+  		{
+      			if (PlayerPrefs.GetFloat(sliderKey) != sliderVal)
+      			{
+          			PlayerPrefs.SetFloat(sliderKey, sliderVal);
+      			}
+  		}
+  		else
+  		{
+      			PlayerPrefs.SetFloat(sliderKey, sliderVal);
+  		}
+
+  		string sliderNickname = slider.GetChild(3).GetComponent<TextMeshProUGUI>().name;
+
+  		slider.GetChild(3).GetComponent<TextMeshProUGUI>().text = string.Format("{0}: {1}", sliderNickname, sliderVal) + "%";
+	}
+
         if (Input.GetKeyDown(KeyCode.BackQuote)) {
             EnableDeveloperTools();
         }


### PR DESCRIPTION
Added Folders which contain (hide) settings named "FolderName/SettingName" until pressed. When pressed, updates nav panel to show all settings with the particular naming scheme as well as "Return" button.
Settings shown within the folder will have "FolderName/" removed.

Added Text boxes which can have custom text entered by the player.
Added Buttons which can be pressed to run a list of Lua functions.


Added Folder, Return, TextField and Button values to SettingType
Added inFolder bool and key string to MPLSetting class


Updated API.txt to include AddSettingFolder, GetSettingFolder, AddSettingTextBox, GetSettingTextBox, AddSettingButton and EditSettingButton.

[Most Important Change] Moved MODS button index to before Close/Abandon Run/Quit button.

Moved settings text alignment to Left rather than Center. Folders use Top Left and Bold to differentiate.
Cleared coloring from Previous and Next buttons when updating page.