### PR TITLE
Fixed Settings Set-On-Create and added fix for base game's unlock cards for Modded characters

### DIFF
--- a/Additions/CustomSettings.cs
+++ b/Additions/CustomSettings.cs
@@ -600,6 +600,7 @@ class SettingsPatch
                         setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + (setting.activeValue > 0 ? "True" : "False");
                         setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
 
+                        PlayerPrefs.SetInt(setting.key, setting.activeValue);
                         Object.DestroyImmediate(setting.settingobj.GetComponent<Button>());
                         {
                             EventTrigger.Entry entry = new EventTrigger.Entry();
@@ -628,6 +629,8 @@ class SettingsPatch
                         setting.control = setting.settingobj.transform.GetChild(0);
                         setting.control.GetComponent<TextMeshProUGUI>().text = setting.name + ": " + setting.values[setting.activeValue];
                         setting.control.GetComponent<I2.Loc.Localize>().Term = "-";
+
+                        PlayerPrefs.SetInt(setting.key, setting.activeValue);
                         Object.DestroyImmediate(setting.settingobj.GetComponent<Button>());
                         {
                             EventTrigger.Entry entry = new EventTrigger.Entry();

--- a/Misc/MPLMisc.cs
+++ b/Misc/MPLMisc.cs
@@ -153,3 +153,25 @@ static class MoreLuaPower_InstallSpeed
             	yield break;
         }
 }
+
+[HarmonyPatch(typeof(UnlockCtrl), nameof(UnlockCtrl.ShowNextUnlock))]
+static class MoreLuaPower_BaseFixes
+{
+    [HarmonyPostfix]
+    internal static void FixUnlockCardSprites()
+    {
+        ChoiceCard shownCard = S.I.unCtrl.shownUnlocks[S.I.unCtrl.shownUnlocks.Count - 1];
+        CharacterCard unlockCard = shownCard.GetComponent<CharacterCard>();
+
+        if (!S.I.itemMan.animations.ContainsKey(unlockCard.beingObj.animName)
+            && S.I.itemMan.spriteAnimClips.ContainsKey(unlockCard.beingObj.animName + "_idle")
+            && unlockCard.gameObject.GetComponent<SpriteAnimator>() == null
+            && unlockCard.charRend != null)
+        {
+            SpriteAnimator animator = unlockCard.gameObject.AddComponent<SpriteAnimator>();
+            animator.spriteRend = unlockCard.charRend;
+            animator.AssignClip(S.I.itemMan.GetClip(unlockCard.beingObj.animName + "_idle"));
+            unlockCard.charAnim.enabled = false;
+        }
+    }
+}


### PR DESCRIPTION
1. Toggle and Rotation settings didn't actually set their default value on creation. This only affects settings with a default value that isn't 0. eg. If the default of a toggle were 1 (true), it was appear as if it were 0 (false) until toggled off and on again.

2. The base game unlock cards use Animators, which pull from the itemManager.animations dictionary. Modded character sprites are in the animationClips dictionary which requires a SpriteAnimator.